### PR TITLE
SO-8983 Fix Thanos query endpoint naming

### DIFF
--- a/apica-ascent/charts/thanos/templates/query/deployment.yaml
+++ b/apica-ascent/charts/thanos/templates/query/deployment.yaml
@@ -121,7 +121,7 @@ spec:
             - --store.sd-files=/conf/servicediscovery.yml
             {{- end }}
             {{- if and .Values.query.dnsDiscovery.enabled }}
-            - --store=dnssrv+_grpc._tcp.{{ .Release.Namespace }}-prometheus-prometheus-thanos.{{ .Release.Namespace }}.svc.cluster.local
+            - --store=dnssrv+_grpc._tcp.{{ .Release.Name }}-prometheus-prometheus-thanos.{{ .Release.Namespace }}.svc.cluster.local
             {{- end }}
             {{- if and .Values.storegateway.enabled .Values.storegateway.sharded.enabled }}
             {{- $shards := int 0 }}


### PR DESCRIPTION
Prefix should be the Helm release name, not the deployment namespace. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Fixes a naming issue in the Thanos query deployment configuration by replacing the release namespace with the correct Helm release name.</li>

<li>Ensures that the query endpoint is accurately identified via service discovery.</li>

<li>Modification is concise and limited to the deployment.yaml file.</li>

<li>Overall, the update resolves a specific bug related to endpoint naming in the Thanos query deployment configuration, specifically updating the deployment.yaml file.</li>

</ul>

</div>