### PR TITLE
SO-9131 Fix prometheus monitoring label for Flash

### DIFF
--- a/apica-ascent/charts/logiq-flash/templates/service-headless.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/service-headless.yaml
@@ -8,7 +8,6 @@ metadata:
     chart: {{ template "logiq-flash.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    promMonitor: {{ template "logiq-flash.name" . }}
 spec:
   clusterIP: None
   ports:

--- a/apica-ascent/charts/logiq-flash/templates/service.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     chart: {{ template "logiq-flash.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    promMonitor: {{ template "logiq-flash.name" . }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
The promMonitor label was added to logiq-flash-headless when it should be on logiq-flash. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Fixes the placement of the promMonitor label in Flash service configurations by removing it from the headless service file and adding it to the proper service file.</li>

<li>Ensures that Prometheus monitoring is applied correctly.</li>

<li>Overall summary: Fixes a configuration error in Flash service configurations by correcting the promMonitor label placement, aligning the service setup with intended monitoring practices.</li>

</ul>

</div>