### PR TITLE
SO-9145 Fix repository names to allow override

### DIFF
--- a/apica-ascent/charts/flash-coffee/values.yaml
+++ b/apica-ascent/charts/flash-coffee/values.yaml
@@ -11,7 +11,7 @@ coffee:
   replicaCount: 2
   web_workers: 4
   image: 
-    repository: docker.io/logiqai/flash-brew-coffee
+    repository: logiqai/flash-brew-coffee
     tag: brew.1.2.0
     pullPolicy: IfNotPresent
   resources: {}
@@ -19,7 +19,7 @@ coffee:
 
 coffee_worker:
   image:
-    repository: docker.io/logiqai/flash-brew-coffee
+    repository: logiqai/flash-brew-coffee
     tag: brew.1.2.0
     pullPolicy: IfNotPresent
   replicaCount: 3

--- a/apica-ascent/charts/flash-discovery/values.yaml
+++ b/apica-ascent/charts/flash-discovery/values.yaml
@@ -7,7 +7,7 @@ useSecret: false
 pullSecretName:
 
 image:
-  repository: docker.io/logiqai/flash-discovery
+  repository: logiqai/flash-discovery
   tag: 1.0.0
   pullPolicy: IfNotPresent
 

--- a/apica-ascent/charts/logiq-flash/values.yaml
+++ b/apica-ascent/charts/logiq-flash/values.yaml
@@ -6,17 +6,17 @@ replicaCount: 3
 replicaCountMl: 1
 
 image:
-  repository: docker.io/logiqai/flash
+  repository: logiqai/flash
   tag: 1.2.0
   pullPolicy: IfNotPresent
 
 sidecarTracing:
-       image: docker.io/logiqai/tracing
+       image: logiqai/tracing
        tag: v1.35.2-lq1-c
        imagePullPolicy: Always
 
 sidecarTracingMl:
-       image: docker.io/logiqai/tracing
+       image: logiqai/tracing
        tag: v1.35.2-lq1-q
        imagePullPolicy: Always
         

--- a/apica-ascent/charts/logiqctl/values.yaml
+++ b/apica-ascent/charts/logiqctl/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: docker.io/logiqai/logiqctl
+  repository: logiqai/logiqctl
   tag: latest
   pullPolicy: Always
 


### PR DESCRIPTION
Do not hardcode Dockerhub so that private registries can be used in air-gapped environments. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Removes hardcoded references to 'docker.io' from repository configurations in Helm charts.</li>

<li>Ensures consistency in repository configurations for flash-coffee, flash-discovery, logiq-flash, and logiqctl charts.</li>

<li>Allows support for private registries in air-gapped environments by enabling deployments to correctly override default settings and use appropriate registry paths.</li>

<li>Overall summary: Corrects repository names across various Helm charts by removing hardcoded 'docker.io' references, ensuring consistency in configurations for flash-coffee, flash-discovery, logiq-flash, and logiqctl charts to support private registries.</li>

</ul>

</div>