### PR TITLE
SO-9193: Fix persistent volume claim definitions in Thanos StatefulSets

### DIFF
--- a/apica-ascent/charts/thanos/templates/receive/statefulset.yaml
+++ b/apica-ascent/charts/thanos/templates/receive/statefulset.yaml
@@ -236,7 +236,9 @@ spec:
           emptyDir: {}
   {{- else if and .Values.receive.persistence.enabled (not .Values.receive.persistence.existingClaim) }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1 
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if .Values.receive.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.receive.persistence.annotations "context" $) | nindent 10 }}

--- a/apica-ascent/charts/thanos/templates/ruler/statefulset.yaml
+++ b/apica-ascent/charts/thanos/templates/ruler/statefulset.yaml
@@ -249,7 +249,9 @@ spec:
           emptyDir: {}
   {{- else if and .Values.ruler.persistence.enabled (not .Values.ruler.persistence.existingClaim) }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if .Values.ruler.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.ruler.persistence.annotations "context" $) | nindent 10 }}


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Fixes issues with persistent volume claim definitions in Thanos StatefulSets by revising the volumeClaimTemplates in both the receive and ruler YAML files.</li>

<li>Incorporates explicit declarations of apiVersion and kind to replace the previous ambiguous metadata usage in the volumeClaimTemplates.</li>

<li>Ensures PVCs are now defined clearly, enabling proper deployment and storage provisioning.</li>

<li>Overall summary: Fixes PVC issues in Thanos StatefulSets and enhances the reliability of statefulset configurations by updating volumeClaimTemplates in the receive and ruler YAML files.</li>

</ul>

</div>