### PR TITLE
ArgoCD health check annotations removed for Prometheus because defaul…

### DIFF
--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -271,19 +271,11 @@ prometheus:
     persistence:
       enabled: true
       size: 20Gi
-    # ArgoCD health check annotation - skips health check for CRD
-    podMetadata:
-      annotations:
-        argocd.argoproj.io/skip-health-check: "true"
   prometheus:
     replicaCount: 1
     persistence:
       enabled: true
       size: 20Gi
-    # ArgoCD health check annotation - skips health check for CRD
-    podMetadata:
-      annotations:
-        argocd.argoproj.io/skip-health-check: "true"
   operator:
     replicaCount: 1
   kube-state-metrics:


### PR DESCRIPTION
…t health check DOESN'T WORK for our Prometheus Operator v0.53.1