### PR TITLE
SO-9204 Update versions to latest prod release

### DIFF
--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: docker.io/logiqai/flash
-    tag: v3.19.2
+    tag: v3.19.5
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -23,7 +23,7 @@ logiq-flash:
         cpu: "1250m"
       requests:
         cpu: "1250m"
-        memory: "2750Mi"
+        memory: "3500Mi"
     ml:
       limits:
         cpu: "1000m"
@@ -143,7 +143,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: docker.io/logiqai/flash-brew-coffee
-      tag: brew.v3.20.1
+      tag: brew.v3.20.3
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -155,11 +155,11 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: docker.io/logiqai/flash-brew-coffee
-      tag: brew.v3.20.1
+      tag: brew.v3.20.3
       pullPolicy: IfNotPresent
     resources:
       requests:
-        memory: "1Gi"
+        memory: "2Gi"
         cpu: "1000m"
       limits:
         cpu: "1000m"


### PR DESCRIPTION
- Also set current prod memory memory requests applications 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Updates production configuration settings in the apica-ascent values file, including bumping version tags from v3.19.2 to v3.19.5 for one image and from brew.v3.20.1 to brew.v3.20.3 for another.</li>

<li>Increases memory resources in two different sections.</li>

<li>Overall: Updates configurations and dependency versions in the apica-ascent values file, enhancing system reliability and resource efficiency in production.</li>

</ul>

</div>