### PR TITLE
SO-9207: Added kafkaSecrets toggle to enable/disable kafka tls secret…

### DIFF
--- a/apica-ascent/charts/logiq-flash/templates/secrets.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/secrets.yaml
@@ -21,3 +21,30 @@ data:
   admin_email: {{ if .Values.global.environment.admin_email }}{{ .Values.global.environment.admin_email | b64enc | quote }}{{ end }}
   admin_password: {{ if .Values.global.environment.admin_password }}{{ .Values.global.environment.admin_password | b64enc | quote }}{{ end }}
 {{- end }}
+
+---
+{{- if .Values.kafkaSecrets.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Namespace }}-ascent-kafka-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: secret-sync
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/name: kafka-tls
+    app: {{ template "logiq-flash.name" . }}
+    chart: {{ template "logiq-flash.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  certificate: {{ .Values.global.environment.kafka_certificate | default "" | b64enc | quote }}
+  private_key: {{ .Values.global.environment.kafka_private_key | default "" | b64enc | quote }}
+  ca_chain: {{ .Values.global.environment.kafka_ca_chain | default "" | b64enc | quote }}
+  issuing_ca: {{ .Values.global.environment.kafka_issuing_ca | default "" | b64enc | quote }}
+  serial_number: {{ .Values.global.environment.kafka_serial_number | default "" | b64enc | quote }}
+  private_key_type: {{ .Values.global.environment.kafka_private_key_type | default "" | b64enc | quote }}
+  expiration: {{ .Values.global.environment.kafka_expiration | default "" | b64enc | quote }}
+{{- end }}
+

--- a/apica-ascent/charts/logiq-flash/templates/secrets.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/secrets.yaml
@@ -22,29 +22,3 @@ data:
   admin_password: {{ if .Values.global.environment.admin_password }}{{ .Values.global.environment.admin_password | b64enc | quote }}{{ end }}
 {{- end }}
 
----
-{{- if .Values.kafkaSecrets.enabled }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Release.Namespace }}-ascent-kafka-cert
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/component: secret-sync
-    app.kubernetes.io/managed-by: helm
-    app.kubernetes.io/name: kafka-tls
-    app: {{ template "logiq-flash.name" . }}
-    chart: {{ template "logiq-flash.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-type: Opaque
-data:
-  certificate: {{ .Values.global.environment.kafka_certificate | default "" | b64enc | quote }}
-  private_key: {{ .Values.global.environment.kafka_private_key | default "" | b64enc | quote }}
-  ca_chain: {{ .Values.global.environment.kafka_ca_chain | default "" | b64enc | quote }}
-  issuing_ca: {{ .Values.global.environment.kafka_issuing_ca | default "" | b64enc | quote }}
-  serial_number: {{ .Values.global.environment.kafka_serial_number | default "" | b64enc | quote }}
-  private_key_type: {{ .Values.global.environment.kafka_private_key_type | default "" | b64enc | quote }}
-  expiration: {{ .Values.global.environment.kafka_expiration | default "" | b64enc | quote }}
-{{- end }}
-

--- a/apica-ascent/charts/logiq-flash/templates/secrets.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/secrets.yaml
@@ -21,4 +21,3 @@ data:
   admin_email: {{ if .Values.global.environment.admin_email }}{{ .Values.global.environment.admin_email | b64enc | quote }}{{ end }}
   admin_password: {{ if .Values.global.environment.admin_password }}{{ .Values.global.environment.admin_password | b64enc | quote }}{{ end }}
 {{- end }}
-

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -105,10 +105,9 @@ spec:
           secret:
             secretName: {{ .Values.global.sharedSecretName }}
         {{ end }}
-        {{ if (.Values.kafkaSecrets.enabled | default false) }}
         - name: apica-kafka-secret
           secret:
-            secretName: {{ . | default (printf "%s-ascent-kafka-cert" .Release.Namespace) }}
+            secretName: {{ . | default ("ascent-kafka-cert") }}
             defaultMode: 420
             items:
               - key: certificate
@@ -117,7 +116,6 @@ spec:
                 path: tls.key
               - key: ca_chain
                 path: ca.crt
-        {{- end }}
       {{ if .Values.podPerNode }}
       affinity:
         podAntiAffinity:
@@ -137,7 +135,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -c
-          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id flash1 -pg_max_idle_conns 190 -pg_max_open_Conns 195 -postgres_timeout 20s -workers 150 -connection_channel_size 10 --pg_conn_max_lifetime 5m {{ .Values.global.environment.extraflag }}
+          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id flash1 -pg_max_idle_conns 190 -pg_max_open_Conns 195 -postgres_timeout 20s -workers 150 -connection_channel_size 10 --pg_conn_max_lifetime 5m {{ .Values.global.environment.extraflag }} {{ .Values.global.environment.kafka_args }}
           command:
           - /bin/bash
           env:
@@ -246,10 +244,8 @@ spec:
           volumeMounts:
           - mountPath: /flash/config
             name: config
-          {{ if .Values.kafkaSecrets.enabled }}
           - mountPath: /flash/kafka
               name: apica-kafka-secret
-          {{- end }}
           - mountPath: /flash/db
             name: data
           {{ if .Values.secrets_name }}

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -105,6 +105,7 @@ spec:
           secret:
             secretName: {{ .Values.global.sharedSecretName }}
         {{ end }}
+        {{- if .Values.vault.enabled }}
         - name: apica-kafka-secret
           secret:
             secretName: {{ . | default ("ascent-kafka-cert") }}
@@ -116,6 +117,7 @@ spec:
                 path: tls.key
               - key: ca_chain
                 path: ca.crt
+        {{- end }}
       {{ if .Values.podPerNode }}
       affinity:
         podAntiAffinity:
@@ -244,8 +246,10 @@ spec:
           volumeMounts:
           - mountPath: /flash/config
             name: config
+          {{- if .Values.vault.enabled }}
           - mountPath: /flash/kafka
               name: apica-kafka-secret
+          {{- end }}
           - mountPath: /flash/db
             name: data
           {{ if .Values.secrets_name }}

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -326,7 +326,6 @@ spec:
           args:
           - -c
           - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id $(DISCOVERY_ID) -pg_max_idle_conns 10 -pg_max_open_Conns 10 -postgres_timeout 20s --pg_conn_max_lifetime 5m -grpc_port 51054 -health_check_port 18080 --sidecar-node -api_port 19999 {{ .Values.global.environment.extraflag }}
-          {{- else }}
           command:
           - /bin/bash
           env:

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -137,7 +137,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -c
-          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id flash1 -pg_max_idle_conns 190 -pg_max_open_Conns 195 -postgres_timeout 20s -workers 150 -connection_channel_size 10 --pg_conn_max_lifetime 5m {{ .Values.global.environment.extraflag }} {{- if .Values.kafka_client.enabled }} {{ .Values.kafka_client.kafka_args }}{{- end }}
+          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id flash1 -pg_max_idle_conns 190 -pg_max_open_Conns 195 -postgres_timeout 20s -workers 150 -connection_channel_size 10 --pg_conn_max_lifetime 5m {{ .Values.global.environment.extraflag }} {{- if .Values.kafka_client.enabled }} {{ .Values.kafka_client.kafka_args }} {{- end }}
           command:
           - /bin/bash
           env:

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -105,6 +105,19 @@ spec:
           secret:
             secretName: {{ .Values.global.sharedSecretName }}
         {{ end }}
+        {{ if (.Values.kafkaSecrets.enabled | default false) }}
+        - name: apica-kafka-secret
+          secret:
+            secretName: {{ . | default (printf "%s-ascent-kafka-cert" .Release.Namespace) }}
+            defaultMode: 420
+            items:
+              - key: certificate
+                path: tls.crt
+              - key: private_key
+                path: tls.key
+              - key: ca_chain
+                path: ca.crt
+        {{- end }}
       {{ if .Values.podPerNode }}
       affinity:
         podAntiAffinity:
@@ -233,6 +246,10 @@ spec:
           volumeMounts:
           - mountPath: /flash/config
             name: config
+          {{ if .Values.kafkaSecrets.enabled }}
+          - mountPath: /flash/kafka
+              name: apica-kafka-secret
+          {{- end }}
           - mountPath: /flash/db
             name: data
           {{ if .Values.secrets_name }}

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -137,7 +137,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -c
-          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id flash1 -pg_max_idle_conns 190 -pg_max_open_Conns 195 -postgres_timeout 20s -workers 150 -connection_channel_size 10 --pg_conn_max_lifetime 5m {{ .Values.global.environment.extraflag }} {{ .Values.global.environment.kafka_args }}
+          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id flash1 -pg_max_idle_conns 190 -pg_max_open_Conns 195 -postgres_timeout 20s -workers 150 -connection_channel_size 10 --pg_conn_max_lifetime 5m {{ .Values.global.environment.extraflag }} {{- if .Values.kafka_client.enabled }} {{ .Values.kafka_client.kafka_args }}{{- end }}
           command:
           - /bin/bash
           env:
@@ -325,7 +325,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -c
-          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id $(DISCOVERY_ID) -pg_max_idle_conns 10 -pg_max_open_Conns 10 -postgres_timeout 20s --pg_conn_max_lifetime 5m -grpc_port 51054 -health_check_port 18080 --sidecar-node -api_port 19999 {{ .Values.global.environment.extraflag }} {{- if .Values.kafka_client.enabled }} {{ .Values.kafka_client.kafka_args }}{{- end }}
+          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id $(DISCOVERY_ID) -pg_max_idle_conns 10 -pg_max_open_Conns 10 -postgres_timeout 20s --pg_conn_max_lifetime 5m -grpc_port 51054 -health_check_port 18080 --sidecar-node -api_port 19999 {{ .Values.global.environment.extraflag }}
           {{- else }}
           command:
           - /bin/bash

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -105,7 +105,7 @@ spec:
           secret:
             secretName: {{ .Values.global.sharedSecretName }}
         {{ end }}
-        {{- if .Values.vault.enabled }}
+        {{- if .Values.kafka_client.enabled }}
         - name: apica-kafka-secret
           secret:
             secretName: {{ . | default ("ascent-kafka-cert") }}
@@ -246,7 +246,7 @@ spec:
           volumeMounts:
           - mountPath: /flash/config
             name: config
-          {{- if .Values.vault.enabled }}
+          {{- if .Values.kafka_client.enabled }}
           - mountPath: /flash/kafka
               name: apica-kafka-secret
           {{- end }}
@@ -325,7 +325,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -c
-          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id $(DISCOVERY_ID) -pg_max_idle_conns 10 -pg_max_open_Conns 10 -postgres_timeout 20s --pg_conn_max_lifetime 5m -grpc_port 51054 -health_check_port 18080 --sidecar-node -api_port 19999 {{ .Values.global.environment.extraflag }}
+          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id $(DISCOVERY_ID) -pg_max_idle_conns 10 -pg_max_open_Conns 10 -postgres_timeout 20s --pg_conn_max_lifetime 5m -grpc_port 51054 -health_check_port 18080 --sidecar-node -api_port 19999 {{ .Values.global.environment.extraflag }} {{- if .Values.kafka_client.enabled }} {{ .Values.kafka_client.kafka_args }}{{- end }}
+          {{- else }}
           command:
           - /bin/bash
           env:

--- a/apica-ascent/charts/logiq-flash/values.yaml
+++ b/apica-ascent/charts/logiq-flash/values.yaml
@@ -205,3 +205,9 @@ global:
     createStorageClass:
        enabled: false
     storageClass: oci-bv
+vault:
+  enabled: false
+  serverCaCertificateB64: ""
+  serverAddress: https://vault.example.com
+  authMount: "k8s-clustername"
+  kafkaClientCertDomain: example.com

--- a/apica-ascent/charts/logiq-flash/values.yaml
+++ b/apica-ascent/charts/logiq-flash/values.yaml
@@ -204,3 +204,5 @@ global:
     createStorageClass:
        enabled: false
     storageClass: oci-bv
+kafkaSecrets:
+  enabled: false

--- a/apica-ascent/charts/logiq-flash/values.yaml
+++ b/apica-ascent/charts/logiq-flash/values.yaml
@@ -211,3 +211,7 @@ vault:
   serverAddress: https://vault.example.com
   authMount: "k8s-clustername"
   kafkaClientCertDomain: example.com
+
+kafka_client:
+  enabled: false
+  kafka_args: ""

--- a/apica-ascent/charts/logiq-flash/values.yaml
+++ b/apica-ascent/charts/logiq-flash/values.yaml
@@ -200,18 +200,10 @@ global:
     AWS_ACCESS_KEY_ID: "AWS_ACCESS" 
     AWS_SECRET_ACCESS_KEY: "AWS_SECRET"
     extraflag: ""
-    kafka_args: ""
   persistence:
     createStorageClass:
        enabled: false
     storageClass: oci-bv
-vault:
-  enabled: false
-  serverCaCertificateB64: ""
-  serverAddress: https://vault.example.com
-  authMount: "k8s-clustername"
-  kafkaClientCertDomain: example.com
-
 kafka_client:
   enabled: false
   kafka_args: ""

--- a/apica-ascent/charts/logiq-flash/values.yaml
+++ b/apica-ascent/charts/logiq-flash/values.yaml
@@ -200,9 +200,8 @@ global:
     AWS_ACCESS_KEY_ID: "AWS_ACCESS" 
     AWS_SECRET_ACCESS_KEY: "AWS_SECRET"
     extraflag: ""
+    kafka_args: ""
   persistence:
     createStorageClass:
        enabled: false
     storageClass: oci-bv
-kafkaSecrets:
-  enabled: false

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -391,3 +391,6 @@ vault:
   serverAddress: https://vault.example.com
   authMount: "k8s-clustername"
   kafkaClientCertDomain: example.com
+kafka_client:
+  enabled: true
+  kafka_args: "-kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt"

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -304,13 +304,14 @@ logiqctl:
     repository: docker.io/logiqai/logiqctl
     tag: 2.0.4
     pullPolicy: IfNotPresent
-
+kafkaSecrets:
+  enabled: true
 global:
   domain: null
   kubeDistributor:
     enabled: false
   cloudProvider: aws
-  # NodePort Configuration
+  # NodePort Configurationl
   nodePort:
     enabled: true # Set to true to enable NodePort services
     ports:
@@ -376,6 +377,14 @@ global:
     external_cert_key: ""
     internal_cert_crt: ""
     internal_cert_key: ""
+    certificate: ""
+    private_key: ""
+    ca_chain: ""
+    issuing_ca: ""
+    serial_number: ""
+    private_key_type: ""
+    expiration: ""
+    extraflag: "-hauler-node-affinity=false --tail_longpoll=true -kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt -persist=true"
   persistence:
     storageClass: oci-bv
   chart:

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -304,8 +304,6 @@ logiqctl:
     repository: docker.io/logiqai/logiqctl
     tag: 2.0.4
     pullPolicy: IfNotPresent
-kafkaSecrets:
-  enabled: true
 global:
   domain: null
   kubeDistributor:

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -375,13 +375,6 @@ global:
     external_cert_key: ""
     internal_cert_crt: ""
     internal_cert_key: ""
-    certificate: ""
-    private_key: ""
-    ca_chain: ""
-    issuing_ca: ""
-    serial_number: ""
-    private_key_type: ""
-    expiration: ""
     extraflag: "-hauler-node-affinity=false --tail_longpoll=true -kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt -persist=true"
   persistence:
     storageClass: oci-bv

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -32,7 +32,9 @@ logiq-flash:
     sync:
       requests:
         cpu: "100m"
-
+  kafka_client:
+    enabled: true
+    kafka_args: "-kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt"
 flash-discovery:
   fullnameOverride: flash-discovery
   image:
@@ -390,6 +392,3 @@ vault:
   serverAddress: https://vault.example.com
   authMount: "k8s-clustername"
   kafkaClientCertDomain: example.com
-kafka_client:
-  enabled: true
-  kafka_args: "-kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt"

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -309,7 +309,7 @@ global:
   kubeDistributor:
     enabled: false
   cloudProvider: aws
-  # NodePort Configurationl
+  # NodePort Configuration
   nodePort:
     enabled: true # Set to true to enable NodePort services
     ports:

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -375,7 +375,8 @@ global:
     external_cert_key: ""
     internal_cert_crt: ""
     internal_cert_key: ""
-    extraflag: "-hauler-node-affinity=false --tail_longpoll=true -kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt -persist=true"
+    kafka_args: "-kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt"
+    extraflag: "-hauler-node-affinity=false --tail_longpoll=true -persist=true"
   persistence:
     storageClass: oci-bv
   chart:

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -375,7 +375,6 @@ global:
     external_cert_key: ""
     internal_cert_crt: ""
     internal_cert_key: ""
-    kafka_args: "-kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt"
     extraflag: "-hauler-node-affinity=false --tail_longpoll=true -persist=true"
   persistence:
     storageClass: oci-bv


### PR DESCRIPTION
… mount in logiq-flash statefulset 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Introduces a new Kafka TLS secret integration feature with Vault configuration settings to enhance security in Kafka-related configurations.</li>

<li>Conditionally creates and mounts Kafka secrets in the application's templates based on the kafkaSecrets toggle and Vault enablement checks.</li>

<li>Updates both the secrets and statefulSet templates to support secure Kafka integration with default secret naming, new Kafka arguments, and conditional logic for Vault integration.</li>

<li>Removes deprecated certificate, key-related fields, and legacy secret blocks from configuration files to streamline the setup.</li>

<li>Refines configurations in multiple values files to improve flexibility, maintainability, consistency, and add new Vault configuration parameters.</li>

<li>Overall, these changes introduce Kafka TLS secret integration enhancements with Vault support, update deployment templates with conditional logic, remove deprecated fields, and enhance the security, consistency, and maintainability of the system's Kafka-related configurations.</li>

</ul>

</div>