### PR TITLE
SO-9207: Add Kafka client secret mount to Logiq Flash StatefulSet

### DIFF
--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -108,7 +108,7 @@ spec:
         {{- if .Values.kafka_client.enabled }}
         - name: apica-kafka-secret
           secret:
-            secretName: {{ . | default ("ascent-kafka-cert") }}
+            secretName: {{ .Values.kafka_client.secretName | default "ascent-kafka-cert" }}
             defaultMode: 420
             items:
               - key: certificate
@@ -248,7 +248,7 @@ spec:
             name: config
           {{- if .Values.kafka_client.enabled }}
           - mountPath: /flash/kafka
-              name: apica-kafka-secret
+            name: apica-kafka-secret
           {{- end }}
           - mountPath: /flash/db
             name: data


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Introduces updates to the Logiq Flash StatefulSet template by adding support for configurable Kafka client secret mounting.</li>

<li>Modifies the secretName definition to pull from chart values.</li>

<li>Adjusts the mount path configuration accordingly.</li>

<li>Overall summary: The changes improve deployment flexibility, ensure consistency in the handling of the Kafka client configuration, and enhance the chart's capability to manage Kafka related secrets dynamically.</li>

</ul>

</div>