### PR TITLE
Add annotations for ArgoCD sync wave and Helm Pre-install hooks

### DIFF
--- a/apica-ascent/templates/vault-secrets.yaml
+++ b/apica-ascent/templates/vault-secrets.yaml
@@ -8,12 +8,20 @@ metadata:
   creationTimestamp: null
   name: vault-ca
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "argocd.argoproj.io/sync-wave": "-1"
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 ---
 apiVersion: secrets.hashicorp.com/v1beta1
 kind: VaultConnection
 metadata:
   name: vault-connection
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "argocd.argoproj.io/sync-wave": "-1"
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   address: {{.Values.vault.serverAddress}}
   skipTLSVerify: false
@@ -24,11 +32,19 @@ kind: ServiceAccount
 metadata:
   name: vso-{{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "argocd.argoproj.io/sync-wave": "-1"
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: "vso-{{ .Release.Namespace }}-tokenreview"
+  annotations:
+    "argocd.argoproj.io/sync-wave": "-1"
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -43,6 +59,10 @@ kind: VaultAuth
 metadata:
   name: vso-auth
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "argocd.argoproj.io/sync-wave": "-1"
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   vaultConnectionRef: vault-connection
   method: kubernetes
@@ -58,6 +78,10 @@ kind: VaultPKISecret
 metadata:
   namespace: {{ .Release.Namespace }}
   name: ascent-kafka-cert
+  annotations:
+    "argocd.argoproj.io/sync-wave": "-1"
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   vaultAuthRef: vso-auth
   mount: pki


### PR DESCRIPTION
Added annotations for ArgoCD sync-wave and Helm hooks to multiple resources in vault-secrets.yaml. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Adds annotations for ArgoCD synchronization and Helm pre-install hooks to the vault-secrets.yaml file across multiple resource sections.</li>

<li>Ensures resources such as vault connections, cluster role bindings, vault auth configurations, and Kafka certificates have the required hook annotations.</li>

<li>Standardizes deployment processes and enhances the execution order during installations.</li>

<li>Overall summary: Updates the vault-secrets.yaml file by adding annotations for ArgoCD synchronization and Helm pre-install hooks across multiple resource sections, leading to a more robust and consistent deployment configuration.</li>

</ul>

</div>