### PR TITLE
Prometheus and Thanos resource request and limit setup

### DIFF
--- a/apica-ascent/charts/kube-prometheus/values.yaml
+++ b/apica-ascent/charts/kube-prometheus/values.yaml
@@ -576,13 +576,7 @@ prometheus:
   ## @param prometheus.resources CPU/Memory resource requests/limits for node
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources:
-    limits:
-      cpu: 1500m
-      memory: 10Gi
-    requests:
-      cpu: 100m
-      memory: 50Mi
+  resources: {}
   ## @param prometheus.podAffinityPreset Prometheus Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##
@@ -988,13 +982,7 @@ prometheus:
     ## @param prometheus.thanos.resources.limits The resources limits for the Thanos sidecar container
     ## @param prometheus.thanos.resources.requests The resources requests for the Thanos sidecar container
     ##
-    resources:
-      limits:
-        cpu: 1500m
-        memory: 10Gi
-      requests:
-        cpu: 100m
-        memory: 50Mi
+    resources: {}
       ## Example:
       ## limits:
       ##    cpu: 100m

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -352,6 +352,12 @@ prometheus:
       objectStorageConfig:
         secretName: thanos-objstore-secret
         secretKey: objstore.yml
+      resources:
+        requests:
+          cpu: 50m
+          memory: 100Mi
+        limits:
+          memory: 200Mi
   operator:
     enabled: true
     replicaCount: 1


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Updates the Prometheus and Thanos sections in the kube-prometheus chart to use empty resource objects instead of fixed limits and requests, possibly to enable dynamic configuration.</li>

<li>Adds explicit resource requests and limits for object storage in the main values file, introducing a new layer of control.</li>

<li>Overall summary: Refines resource configurations across multiple components in the kube-prometheus chart and main values file, enhancing configuration flexibility and consistency.</li>

</ul>

</div>