### PR TITLE
Increase memory limit from 3000Mi to 6000Mi

### DIFF
--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -342,7 +342,7 @@ prometheus:
         memory: 500Mi
         cpu: 300m
       limits:
-        memory: 3000Mi
+        memory: 6000Mi
     replicaCount: 2
     persistence:
       enabled: true


### PR DESCRIPTION
need more resources for restore 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Increases the memory limit in the deployment configuration to meet higher resource demands for restore operations.</li>

<li>Modifies the values.yaml file to ensure the application receives more memory.</li>

<li>Represents a targeted improvement in the resource allocation strategy.</li>

<li>Overall summary: Introduces an increase in memory limit via the values.yaml file to enhance resource allocation for restore operations, boosting system reliability.</li>

</ul>

</div>