### PR TITLE
Update Prometheus memory requests and limits

### DIFF
--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -349,10 +349,10 @@ prometheus:
     enabled: true
     resources:
       requests:
-        memory: 500Mi
+        memory: 15Gi
         cpu: 300m
       limits:
-        memory: 6000Mi
+        memory: 15Gi
     replicaCount: 2
     persistence:
       enabled: true


### PR DESCRIPTION
Increased memory requests and limits for Prometheus. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Increases memory requests and limits for Prometheus to 15Gi in apica-ascent/values.yaml.</li>

<li>Modifies deployment settings in apica-ascent/values.yaml to address potential resource constraints.</li>

<li>Aims to improve overall performance, scalability, and system stability by aligning configuration with required demands.</li>

<li>Overall summary: Enhances resource configuration in apica-ascent/values.yaml, improving performance and scalability.</li>

</ul>

</div>