### PR TITLE
SO-9339 reducing the prometheus rention to 4 days 

### DIFF
--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -340,6 +340,7 @@ apicaTLSSecret:
 
 prometheus:
   fullnameOverride: prometheus
+  retention: 4d
   persistence:
     enabled: true
     size: 20Gi
@@ -351,7 +352,6 @@ prometheus:
       size: 20Gi
   prometheus:
     enabled: true
-    retention: 4d
     resources:
       requests:
         memory: 15Gi

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -340,7 +340,6 @@ apicaTLSSecret:
 
 prometheus:
   fullnameOverride: prometheus
-  retention: 7d
   persistence:
     enabled: true
     size: 20Gi

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -351,6 +351,7 @@ prometheus:
       size: 20Gi
   prometheus:
     enabled: true
+    retention: 4d
     resources:
       requests:
         memory: 15Gi

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -340,7 +340,7 @@ apicaTLSSecret:
 
 prometheus:
   fullnameOverride: prometheus
-  retention: 4d
+  retention: 7d
   persistence:
     enabled: true
     size: 20Gi
@@ -352,6 +352,7 @@ prometheus:
       size: 20Gi
   prometheus:
     enabled: true
+    retention: 7d
     resources:
       requests:
         memory: 15Gi


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request updates the Prometheus configuration in the Helm chart to reduce the data retention period to 4 days by removing the explicit retention setting.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes the 'retention: 7d' configuration from the prometheus section in values.yaml, allowing the default 4-day retention period to apply.</li>

</ul>
</details>

</div>