### PR TITLE
SO-9261 Add flash args for logflow-only mode

### DIFF
--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -137,7 +137,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -c
-          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id flash1 -pg_max_idle_conns 190 -pg_max_open_Conns 195 -postgres_timeout 20s -workers 150 -connection_channel_size 10 --pg_conn_max_lifetime 5m {{ .Values.global.environment.extraflag }} {{- if .Values.kafka_client.enabled }} {{ .Values.kafka_client.kafka_args }} {{- end }}
+          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id flash1 -pg_max_idle_conns 190 -pg_max_open_Conns 195 -postgres_timeout 20s -workers 150 -connection_channel_size 10 --pg_conn_max_lifetime 5m {{ .Values.global.environment.extraflag }} {{- if .Values.logflow_only.enabled }} {{ .Values.logflow_only.args }} {{- end }} {{- if .Values.kafka_client.enabled }} {{ .Values.kafka_client.kafka_args }} {{- end }}
           command:
           - /bin/bash
           env:

--- a/apica-ascent/values.large.yaml
+++ b/apica-ascent/values.large.yaml
@@ -51,6 +51,9 @@ logiq-flash:
         memory: 300Mi
       limits:
         memory: 750Mi
+  logflow_only:
+    enabled: false
+    args: -object_writers=1 -max_bytes_per_sec=833331
   kafka_client:
     enabled: false
     kafka_args: -kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt

--- a/apica-ascent/values.medium.yaml
+++ b/apica-ascent/values.medium.yaml
@@ -51,6 +51,9 @@ logiq-flash:
         memory: 300Mi
       limits:
         memory: 750Mi
+  logflow_only:
+    enabled: false
+    args: -object_writers=1 -max_bytes_per_sec=833331
   kafka_client:
     enabled: false
     kafka_args: -kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt

--- a/apica-ascent/values.single.yaml
+++ b/apica-ascent/values.single.yaml
@@ -51,6 +51,9 @@ logiq-flash:
         memory: 300Mi
       limits:
         memory: 750Mi
+  logflow_only:
+    enabled: false
+    args: -object_writers=1 -max_bytes_per_sec=833331
   kafka_client:
     enabled: false
     kafka_args: -kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt

--- a/apica-ascent/values.small.yaml
+++ b/apica-ascent/values.small.yaml
@@ -51,6 +51,9 @@ logiq-flash:
         memory: 300Mi
       limits:
         memory: 750Mi
+  logflow_only:
+    enabled: false
+    args: -object_writers=1 -max_bytes_per_sec=833331
   kafka_client:
     enabled: false
     kafka_args: -kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -54,6 +54,9 @@ logiq-flash:
         memory: 300Mi
       limits:
         memory: 750Mi
+  logflow_only:
+    enabled: false
+    args: '-object_writers=1 -max_bytes_per_sec=833331'
   kafka_client:
     enabled: true
     kafka_args: "-kafka_ca_cert_path=/flash/kafka/ca.crt -kafka_client_key_path=/flash/kafka/tls.key -kafka_client_cert_path=/flash/kafka/tls.crt"


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request adds support for logflow-only mode configuration in the logiq-flash component of the apica-ascent Helm chart, introducing conditional arguments and default values for different deployment sizes.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>adds logflow_only configuration section to values.large.yaml, values.medium.yaml, values.single.yaml, values.small.yaml, and values.yaml with enabled set to false and default args</li>

<li>modifies statefulSet.yaml to conditionally append logflow_only.args to the flash command arguments when logflow_only.enabled is true</li>

</ul>
</details>

</div>