### PR TITLE
Added ArgoCd No Resource Deletion sync policy annotation

### DIFF
--- a/apica-ascent/charts/flash-discovery/templates/discoveryStatefulSet.yaml
+++ b/apica-ascent/charts/flash-discovery/templates/discoveryStatefulSet.yaml
@@ -20,6 +20,8 @@ spec:
     kind: PersistentVolumeClaim
     metadata:
       name: data
+      annotations:
+        argocd.argoproj.io/sync-options: Delete=false
     spec:
       accessModes:
         - ReadWriteOnce

--- a/apica-ascent/charts/grafana/templates/pvc.yaml
+++ b/apica-ascent/charts/grafana/templates/pvc.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "grafana.labels" . | nindent 4 }}
     app.kubernetes.io/component: grafana
+  annotations:
+    argocd.argoproj.io/sync-options: Delete=false
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -20,6 +20,8 @@ spec:
     kind: PersistentVolumeClaim
     metadata:
       name: data
+      annotations:
+        argocd.argoproj.io/sync-options: Delete=false
     spec:
       accessModes:
         - ReadWriteOnce

--- a/apica-ascent/charts/logiq-flash/templates/statefulset-ml.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulset-ml.yaml
@@ -20,6 +20,8 @@ spec:
     kind: PersistentVolumeClaim
     metadata:
       name: data
+      annotations:
+        argocd.argoproj.io/sync-options: Delete=false
     spec:
       accessModes:
         - ReadWriteOnce

--- a/apica-ascent/charts/minio/templates/pvc.yaml
+++ b/apica-ascent/charts/minio/templates/pvc.yaml
@@ -10,6 +10,8 @@ metadata:
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    argocd.argoproj.io/sync-options: Delete=false
 spec:
 {{- if and .Values.nasgateway.enabled .Values.nasgateway.pv }}
   selector:

--- a/apica-ascent/charts/minio/templates/statefulset.yaml
+++ b/apica-ascent/charts/minio/templates/statefulset.yaml
@@ -300,6 +300,8 @@ spec:
     {{- range $diskId := until $drivesPerNode}}
     - metadata:
         name: export-{{ $diskId }}
+        annotations:
+          argocd.argoproj.io/sync-options: Delete=false
       spec:
         accessModes: [ {{ $accessMode | quote }} ]
         {{- if $storageClass }}
@@ -312,6 +314,8 @@ spec:
   {{- else }}
     - metadata:
         name: export
+        annotations:
+          argocd.argoproj.io/sync-options: Delete=false
       spec:
         accessModes: [ {{ $accessMode | quote }} ]
         {{- if $storageClass }}

--- a/apica-ascent/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/apica-ascent/charts/postgresql/templates/statefulset-slaves.yaml
@@ -295,12 +295,13 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
-      {{- with .Values.persistence.annotations }}
         annotations:
+          argocd.argoproj.io/sync-options: Delete=false
+        {{- with .Values.persistence.annotations }}
         {{- range $key, $value := . }}
           {{ $key }}: {{ $value }}
         {{- end }}
-      {{- end }}
+        {{- end }}
       spec:
         accessModes:
         {{- range .Values.persistence.accessModes }}

--- a/apica-ascent/charts/postgresql/templates/statefulset.yaml
+++ b/apica-ascent/charts/postgresql/templates/statefulset.yaml
@@ -453,12 +453,13 @@ spec:
       kind: PersistentVolumeClaim
       metadata:
         name: data
-      {{- with .Values.persistence.annotations }}
         annotations:
+          argocd.argoproj.io/sync-options: Delete=false
+        {{- with .Values.persistence.annotations }}
         {{- range $key, $value := . }}
           {{ $key }}: {{ $value }}
         {{- end }}
-      {{- end }}
+        {{- end }}
       spec:
         accessModes:
         {{- range .Values.persistence.accessModes }}

--- a/apica-ascent/charts/redis/templates/redis-master-statefulset.yaml
+++ b/apica-ascent/charts/redis/templates/redis-master-statefulset.yaml
@@ -415,6 +415,8 @@ spec:
           release: {{ .Release.Name }}
           heritage: {{ .Release.Service }}
           component: master
+        annotations:
+          argocd.argoproj.io/sync-options: Delete=false
       spec:
         accessModes:
         {{- range .Values.master.persistence.accessModes }}

--- a/apica-ascent/charts/redis/templates/redis-slave-statefulset.yaml
+++ b/apica-ascent/charts/redis/templates/redis-slave-statefulset.yaml
@@ -431,6 +431,8 @@ spec:
           release: {{ .Release.Name }}
           heritage: {{ .Release.Service }}
           component: slave
+        annotations:
+          argocd.argoproj.io/sync-options: Delete=false
       spec:
         accessModes:
         {{- range .Values.slave.persistence.accessModes }}

--- a/apica-ascent/charts/thanos/templates/compactor/pvc.yaml
+++ b/apica-ascent/charts/thanos/templates/compactor/pvc.yaml
@@ -9,15 +9,14 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.compactor.persistence.annotations .Values.commonAnnotations }}
   annotations:
+    argocd.argoproj.io/sync-options: Delete=false
     {{- if .Values.compactor.persistence.annotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.compactor.persistence.annotations "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- end }}
 spec:
   accessModes:
   {{- range .Values.compactor.persistence.accessModes }}

--- a/apica-ascent/charts/thanos/templates/receive/statefulset.yaml
+++ b/apica-ascent/charts/thanos/templates/receive/statefulset.yaml
@@ -236,12 +236,14 @@ spec:
           emptyDir: {}
   {{- else if and .Values.receive.persistence.enabled (not .Values.receive.persistence.existingClaim) }}
   volumeClaimTemplates:
-    - apiVersion: v1 
+    - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
         name: data
+        annotations:
+          argocd.argoproj.io/sync-options: Delete=false
         {{- if .Values.receive.persistence.annotations }}
-        annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.receive.persistence.annotations "context" $) | nindent 10 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.receive.persistence.annotations "context" $) | nindent 10 }}
         {{- end }}
       spec:
         accessModes:

--- a/apica-ascent/charts/thanos/templates/ruler/statefulset.yaml
+++ b/apica-ascent/charts/thanos/templates/ruler/statefulset.yaml
@@ -253,8 +253,10 @@ spec:
       kind: PersistentVolumeClaim
       metadata:
         name: data
+        annotations:
+          argocd.argoproj.io/sync-options: Delete=false
         {{- if .Values.ruler.persistence.annotations }}
-        annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.ruler.persistence.annotations "context" $) | nindent 10 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.ruler.persistence.annotations "context" $) | nindent 10 }}
         {{- end }}
       spec:
         accessModes:

--- a/apica-ascent/charts/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/apica-ascent/charts/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -283,6 +283,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        annotations:
+          argocd.argoproj.io/sync-options: Delete=false
       spec:
         accessModes:
         {{- range $.Values.storegateway.persistence.accessModes }}

--- a/apica-ascent/charts/thanos/templates/storegateway/statefulset.yaml
+++ b/apica-ascent/charts/thanos/templates/storegateway/statefulset.yaml
@@ -249,8 +249,10 @@ spec:
       kind: PersistentVolumeClaim
       metadata:
         name: data
+        annotations:
+          argocd.argoproj.io/sync-options: Delete=false
         {{- if .Values.storegateway.persistence.annotations }}
-        annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.storegateway.persistence.annotations "context" $) | nindent 10 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.storegateway.persistence.annotations "context" $) | nindent 10 }}
         {{- end }}
       spec:
         accessModes:

--- a/apica-ascent/templates/gateway.yaml
+++ b/apica-ascent/templates/gateway.yaml
@@ -10,6 +10,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "logiq.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-options: Delete=false
 spec:
   # Reference to per-namespace GatewayClass
   # The GatewayClass has parametersRef pointing to EnvoyProxy config


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request introduces ArgoCD sync policy annotations to PersistentVolumeClaims across multiple Helm charts, preventing unintended resource deletion during ArgoCD sync operations and enhancing data persistence in Kubernetes deployments.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds argocd.argoproj.io/sync-options: Delete=false annotation to PVC metadata in flash-discovery and grafana charts</li>

<li>Adds argocd.argoproj.io/sync-options: Delete=false annotation to PVC metadata in logiq-flash and minio charts</li>

<li>Adds argocd.argoproj.io/sync-options: Delete=false annotation to PVC metadata in postgresql and redis charts</li>

<li>Adds argocd.argoproj.io/sync-options: Delete=false annotation to PVC metadata in thanos chart and gateway template</li>

</ul>
</details>

</div>