### PR TITLE
SO-9429 Sync onprem sample values

### DIFF
--- a/apica-ascent/update-onprem-values.pl
+++ b/apica-ascent/update-onprem-values.pl
@@ -75,6 +75,10 @@ foreach my $size (@tshirts) {
     # Envoy proxy annotations not needed
     delete $clone->{envoyGateway}{envoyProxy}{provider}{service}{annotations};
 
+    # Restore original prometheus resources
+    $clone->{prometheus}{prometheus}{resources}{requests}{memory} = '500Mi';
+    $clone->{prometheus}{prometheus}{resources}{limits}{memory}   = '6000Mi';
+
     # Reduce memory limits for single-node
     if ($size eq 'single') {
         $clone->{postgres}{resources}{limits}{memory}               = '8000Mi';

--- a/apica-ascent/values.large.yaml
+++ b/apica-ascent/values.large.yaml
@@ -264,6 +264,10 @@ thanos:
       cpu: 50m
     limits:
       memory: 200Mi
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
   storegateway:
     enabled: true
     requests:
@@ -287,7 +291,6 @@ gateway:
     secretName: my-ascent-ingress
 envoyGateway:
   enabled: true
-  
   gatewayClass:
     controllerName: gateway.envoyproxy.io/gatewayclass-controller
     description: Envoy Gateway for Apica Ascent
@@ -311,11 +314,8 @@ envoyGateway:
     - name: tcp-8081
       port: 8081
       protocol: TCP
-
-  # Compression configuration using BackendTrafficPolicy compressor field
   compressor:
     enabled: true
-    # Compression quality (1-9, where 6 is default, 9 is best compression)
     quality: 6
 apicaTLSSecret:
   enabled: true

--- a/apica-ascent/values.medium.yaml
+++ b/apica-ascent/values.medium.yaml
@@ -264,6 +264,10 @@ thanos:
       cpu: 50m
     limits:
       memory: 200Mi
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
   storegateway:
     enabled: true
     requests:
@@ -287,7 +291,6 @@ gateway:
     secretName: my-ascent-ingress
 envoyGateway:
   enabled: true
-  
   gatewayClass:
     controllerName: gateway.envoyproxy.io/gatewayclass-controller
     description: Envoy Gateway for Apica Ascent
@@ -311,11 +314,8 @@ envoyGateway:
     - name: tcp-8081
       port: 8081
       protocol: TCP
-
-  # Compression configuration using BackendTrafficPolicy compressor field
   compressor:
     enabled: true
-    # Compression quality (1-9, where 6 is default, 9 is best compression)
     quality: 6
 apicaTLSSecret:
   enabled: true

--- a/apica-ascent/values.single.yaml
+++ b/apica-ascent/values.single.yaml
@@ -264,6 +264,10 @@ thanos:
       cpu: 50m
     limits:
       memory: 200Mi
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
   storegateway:
     enabled: true
     requests:
@@ -287,7 +291,6 @@ gateway:
     secretName: my-ascent-ingress
 envoyGateway:
   enabled: true
-  
   gatewayClass:
     controllerName: gateway.envoyproxy.io/gatewayclass-controller
     description: Envoy Gateway for Apica Ascent
@@ -311,11 +314,8 @@ envoyGateway:
     - name: tcp-8081
       port: 8081
       protocol: TCP
-
-  # Compression configuration using BackendTrafficPolicy compressor field
   compressor:
     enabled: true
-    # Compression quality (1-9, where 6 is default, 9 is best compression)
     quality: 6
 apicaTLSSecret:
   enabled: true

--- a/apica-ascent/values.small.yaml
+++ b/apica-ascent/values.small.yaml
@@ -264,6 +264,10 @@ thanos:
       cpu: 50m
     limits:
       memory: 200Mi
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
   storegateway:
     enabled: true
     requests:
@@ -287,7 +291,6 @@ gateway:
     secretName: my-ascent-ingress
 envoyGateway:
   enabled: true
-  
   gatewayClass:
     controllerName: gateway.envoyproxy.io/gatewayclass-controller
     description: Envoy Gateway for Apica Ascent
@@ -311,11 +314,8 @@ envoyGateway:
     - name: tcp-8081
       port: 8081
       protocol: TCP
-
-  # Compression configuration using BackendTrafficPolicy compressor field
   compressor:
     enabled: true
-    # Compression quality (1-9, where 6 is default, 9 is best compression)
     quality: 6
 apicaTLSSecret:
   enabled: true

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -342,6 +342,7 @@ envoyGateway:
   compressor:
     enabled: true
     # Compression quality (1-9, where 6 is default, 9 is best compression)
+    quality: 6
 apicaTLSSecret:
   enabled: true
 


### PR DESCRIPTION
Modify update script to reset prometheus memory resources to baseline.

Add Envoy compression default level to main values. Previously it was added only to the onprem samples. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR modifies the update script to reset Prometheus memory resources to baseline values and adds the Envoy compression default level to the main values.yaml, synchronizing it with the onprem sample values. Additionally, it enables Thanos metrics in the sample value files.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Modifies update-onprem-values.pl to reset Prometheus memory resources to baseline values (500Mi requests, 6000Mi limits).</li>

<li>Adds Thanos metrics configuration (enabled: true, serviceMonitor: enabled: true) to sample value files (values.large.yaml, values.medium.yaml, values.single.yaml, values.small.yaml).</li>

<li>Adds Envoy compression quality setting (quality: 6) to main values.yaml, synchronizing it with onprem samples.</li>

</ul>
</details>

</div>