### PR TITLE
CM-1038 - Updated default tag values to latest Ascent 2.15.2 tags

### DIFF
--- a/apica-ascent/values.large.yaml
+++ b/apica-ascent/values.large.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.20.0
+    tag: v3.20.2
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.0
+      tag: brew.v3.21.2
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 4
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.0
+      tag: brew.v3.21.2
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.medium.yaml
+++ b/apica-ascent/values.medium.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.20.0
+    tag: v3.20.2
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.0
+      tag: brew.v3.21.2
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 3
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.0
+      tag: brew.v3.21.2
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.single.yaml
+++ b/apica-ascent/values.single.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.20.0
+    tag: v3.20.2
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 1
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.0
+      tag: brew.v3.21.2
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 1
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.0
+      tag: brew.v3.21.2
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.small.yaml
+++ b/apica-ascent/values.small.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.20.0
+    tag: v3.20.2
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.0
+      tag: brew.v3.21.2
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.0
+      tag: brew.v3.21.2
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.20.0
+    tag: v3.20.2
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -184,7 +184,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.0
+      tag: brew.v3.21.2
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -196,7 +196,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.0
+      tag: brew.v3.21.2
       pullPolicy: IfNotPresent
     resources:
       requests:


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request updates the default Docker image tags in the Apica Ascent Helm values files to the latest versions for Ascent 2.15.2. The changes standardize image tags across different deployment configurations, ensuring users deploy with the most recent Ascent components. This maintains compatibility while providing access to the latest features and fixes.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updated logiq-flash image tag from v3.20.0 to v3.20.2 in all values files (values.yaml, values.large.yaml, values.medium.yaml, values.single.yaml, values.small.yaml).</li>

<li>Updated flash-coffee image tag from brew.v3.21.0 to brew.v3.21.2 for both replicaCount configurations in each values file.</li>

</ul>
</details>

</div>