### PR TITLE
SO-9390 Sync appVersion with Ascent version

### DIFF
--- a/apica-ascent/Chart.yaml
+++ b/apica-ascent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v3.10.2
+appVersion: v2.15.0
 version: 3.0.2
 description: Apica Ascent - Cloud-native observability platform with Envoy Gateway
 keywords:


### PR DESCRIPTION
This is set to 2.15.0 because that is what the tags in values.yaml currently indicate. This should be updated when those tags are updated to the latest release. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>The pull request updates the appVersion in the Apica Ascent Helm chart from v3.10.2 to v2.15.0 to synchronize with the latest Ascent release version. This change addresses the previous setting of 2.14.0, which was based on tags in values.yaml, and updates it to 2.15.0 as the latest release.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates appVersion in Chart.yaml from v3.10.2 to v2.15.0 in Chart.yaml.</li>

<li>Ensures Helm chart metadata aligns with the current Ascent application version.</li>

<li>No changes to dependencies or configurations in the chart.</li>

</ul>
</details>

</div>