### PR TITLE
SO-9497 Opened 14250, 20514 and 14268 ports by default through helm c…

### DIFF
--- a/apica-ascent/templates/tcproute.yaml
+++ b/apica-ascent/templates/tcproute.yaml
@@ -43,4 +43,70 @@ spec:
           name: logiq-flash-ml
           port: 8081
           weight: 1
+---
+# TCPRoute for port 14250 - Jaeger gRPC (OpenTelemetry)
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: {{ .Release.Name }}-tcp-14250
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "logiq.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io	
+      kind: Gateway
+      name: {{ .Release.Name }}-gateway
+      sectionName: tcp-14250
+  rules:
+    - backendRefs:
+        - group: ''	
+          kind: Service
+          name: logiq-flash
+          port: 14250
+          weight: 1
+---
+# TCPRoute for port 20514 - Jaeger HTTP (OpenTelemetry)
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: {{ .Release.Name }}-tcp-20514
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "logiq.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io	
+      kind: Gateway
+      name: {{ .Release.Name }}-gateway
+      sectionName: tcp-20514
+  rules:
+    - backendRefs:
+        - group: ''	
+          kind: Service
+          name: logiq-flash
+          port: 20514
+          weight: 1
+---
+# TCPRoute for port 14268 - Jaeger HTTP (OpenTelemetry)
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: {{ .Release.Name }}-tcp-14268
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "logiq.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io	
+      kind: Gateway
+      name: {{ .Release.Name }}-gateway
+      sectionName: tcp-14268
+  rules:
+    - backendRefs:
+        - group: ''	
+          kind: Service
+          name: logiq-flash
+          port: 14268
+          weight: 1
 {{- end }}

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -337,6 +337,15 @@ envoyGateway:
       - name: tcp-8081
         port: 8081
         protocol: TCP
+      - name: tcp-14250
+        port: 14250
+        protocol: TCP
+      - name: tcp-20514
+        port: 20514
+        protocol: TCP
+      - name: tcp-14268
+        port: 14268
+        protocol: TCP
 
   # Compression configuration using BackendTrafficPolicy compressor field
   compressor:


### PR DESCRIPTION
…hart 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request updates the Apica Ascent Helm chart to expose three additional TCP ports (14250, 20514, and 14268) by default, enabling OpenTelemetry Jaeger gRPC and HTTP endpoints through the Envoy Gateway.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds TCPRoute resources in tcproute.yaml for routing traffic to logiq-flash service on ports 14250, 20514, and 14268.</li>

<li>Updates values.yaml to include TCP listener configurations for the new ports in the envoyGateway.listeners section.</li>

</ul>
</details>

</div>