### PR TITLE
Updated Coffee + Flash tags for Ascent 2.15.3

### DIFF
--- a/apica-ascent/values.large.yaml
+++ b/apica-ascent/values.large.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.20.2
+    tag: v3.20.3
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.2
+      tag: brew.v3.21.3
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 4
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.2
+      tag: brew.v3.21.3
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.medium.yaml
+++ b/apica-ascent/values.medium.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.20.2
+    tag: v3.20.3
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.2
+      tag: brew.v3.21.3
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 3
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.2
+      tag: brew.v3.21.3
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.single.yaml
+++ b/apica-ascent/values.single.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.20.2
+    tag: v3.20.3
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 1
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.2
+      tag: brew.v3.21.3
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 1
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.2
+      tag: brew.v3.21.3
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.small.yaml
+++ b/apica-ascent/values.small.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.20.2
+    tag: v3.20.3
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.2
+      tag: brew.v3.21.3
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.2
+      tag: brew.v3.21.3
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.20.2
+    tag: v3.20.3
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -184,7 +184,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.2
+      tag: brew.v3.21.3
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -196,7 +196,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.21.2
+      tag: brew.v3.21.3
       pullPolicy: IfNotPresent
     resources:
       requests:


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request updates the Docker image tags for the Flash and Coffee components in the Apica Ascent Helm chart values files to versions compatible with Ascent 2.15.3.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates logiq-flash image tag from v3.20.2 to v3.20.3 in values.large.yaml, values.medium.yaml, values.single.yaml, values.small.yaml, and values.yaml</li>

<li>Updates flash-brew-coffee image tag from brew.v3.21.2 to brew.v3.21.3 in values.large.yaml, values.medium.yaml, values.single.yaml, values.small.yaml, and values.yaml</li>

</ul>
</details>

</div>