### PR TITLE
SO-9497 Add new ports to onprem files

### DIFF
--- a/apica-ascent/values.large.yaml
+++ b/apica-ascent/values.large.yaml
@@ -314,6 +314,15 @@ envoyGateway:
     - name: tcp-8081
       port: 8081
       protocol: TCP
+    - name: tcp-14250
+      port: 14250
+      protocol: TCP
+    - name: tcp-20514
+      port: 20514
+      protocol: TCP
+    - name: tcp-14268
+      port: 14268
+      protocol: TCP
   compressor:
     enabled: true
     quality: 6

--- a/apica-ascent/values.medium.yaml
+++ b/apica-ascent/values.medium.yaml
@@ -314,6 +314,15 @@ envoyGateway:
     - name: tcp-8081
       port: 8081
       protocol: TCP
+    - name: tcp-14250
+      port: 14250
+      protocol: TCP
+    - name: tcp-20514
+      port: 20514
+      protocol: TCP
+    - name: tcp-14268
+      port: 14268
+      protocol: TCP
   compressor:
     enabled: true
     quality: 6

--- a/apica-ascent/values.single.yaml
+++ b/apica-ascent/values.single.yaml
@@ -314,6 +314,15 @@ envoyGateway:
     - name: tcp-8081
       port: 8081
       protocol: TCP
+    - name: tcp-14250
+      port: 14250
+      protocol: TCP
+    - name: tcp-20514
+      port: 20514
+      protocol: TCP
+    - name: tcp-14268
+      port: 14268
+      protocol: TCP
   compressor:
     enabled: true
     quality: 6

--- a/apica-ascent/values.small.yaml
+++ b/apica-ascent/values.small.yaml
@@ -314,6 +314,15 @@ envoyGateway:
     - name: tcp-8081
       port: 8081
       protocol: TCP
+    - name: tcp-14250
+      port: 14250
+      protocol: TCP
+    - name: tcp-20514
+      port: 20514
+      protocol: TCP
+    - name: tcp-14268
+      port: 14268
+      protocol: TCP
   compressor:
     enabled: true
     quality: 6


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request adds three new TCP ports to the Envoy Gateway service configuration across all deployment size variants in the Helm chart values files, facilitating access to additional services in on-premise deployments of the Apica Ascent application.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds three new TCP ports (14250, 20514, 14268) to the envoyGateway service in values.large.yaml, values.medium.yaml, values.single.yaml, and values.small.yaml</li>

</ul>
</details>

</div>