### PR TITLE
OPL-14626 Set query connections to 10

### DIFF
--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -325,7 +325,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -c
-          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id $(DISCOVERY_ID) -pg_max_idle_conns 3 -pg_max_open_Conns 5 -postgres_timeout 20s --pg_conn_max_lifetime 5m -grpc_port 51054 -health_check_port 18080 --sidecar-node -api_port 19999 {{ .Values.global.environment.extraflag }}
+          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id $(DISCOVERY_ID) -pg_max_idle_conns 3 -pg_max_open_Conns 10 -postgres_timeout 20s --pg_conn_max_lifetime 5m -grpc_port 51054 -health_check_port 18080 --sidecar-node -api_port 19999 {{ .Values.global.environment.extraflag }}
           command:
           - /bin/bash
           env:


### PR DESCRIPTION
Got reverted by mistake in a previous PR. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request restores the PostgreSQL maximum open connections setting for the flash service to 10, addressing a previous accidental reversion.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Increases the pg_max_open_Conns parameter from 5 to 10 in the flash container arguments within statefulSet.yaml</li>

</ul>
</details>

</div>