### PR TITLE
SO-9542 Remove helm hooks from envoyproxy to prevent unnecessary recreation

### DIFF
--- a/apica-ascent/templates/envoyproxy.yaml
+++ b/apica-ascent/templates/envoyproxy.yaml
@@ -8,10 +8,6 @@ kind: EnvoyProxy
 metadata:
   name: {{ .Release.Name }}-envoy-config
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-10"
-    "helm.sh/hook-delete-policy": before-hook-creation
   labels:
     {{- include "logiq.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request removes Helm hook annotations from the EnvoyProxy resource to prevent its unnecessary recreation during Helm chart upgrades.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes 'helm.sh/hook', 'helm.sh/hook-weight', and 'helm.sh/hook-delete-policy' annotations from EnvoyProxy metadata in envoyproxy.yaml to disable hook behavior and prevent recreation.</li>

</ul>
</details>

</div>