### PR TITLE
[OPL-14808] Add SSR report generator container to coffee worker

### DIFF
--- a/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
@@ -280,4 +280,18 @@ spec:
           {{- if .Values.coffee_worker.resources }}
           resources: {{- toYaml .Values.coffee_worker.resources | nindent 12 }}
           {{- end }}
+        - name: ssr-report-gen
+          image: {{ .Values.global.imageRegistry}}/logiqai/ssr-server:ssr-v16.0.1-fc1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SSR_HOST
+              value: 0.0.0.0
+            - name: __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS
+              value: coffee
+          ports:
+            - containerPort: 5173
+              name: ssr
+              protocol: TCP
+          resources: {}
+          
       restartPolicy: Always


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request adds a new sidecar container to the coffee worker StatefulSet in the Helm chart, enabling SSR report generation capabilities alongside the existing coffee worker functionality.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds a new container 'ssr-report-gen' to the coffee-worker pod spec in 003-coffee-worker-sts.yaml, utilizing the logiqai/ssr-server image version ssr-v16.0.1-fc1</li>

<li>Configures environment variables SSR_HOST set to 0.0.0.0 and __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS set to 'coffee' for the SSR container</li>

<li>Exposes container port 5173 named 'ssr' with TCP protocol for external access</li>

<li>Sets empty resources object for the new container, relying on default Kubernetes resource allocation</li>

</ul>
</details>

</div>