### PR TITLE
[OPL-14808] Remove ssr-report-gen container from coffee server

### DIFF
--- a/apica-ascent/charts/flash-coffee/templates/001-coffee-server-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/001-coffee-server-sts.yaml
@@ -351,18 +351,5 @@ spec:
           resources:
             {{- toYaml .Values.coffee.resources | nindent 12 }}
           {{- end }}
-        - name: ssr-report-gen
-          image: {{ .Values.global.imageRegistry}}/logiqai/ssr-server:v12
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: SSR_HOST
-              value: 0.0.0.0
-            - name: __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS
-              value: coffee
-          ports:
-            - containerPort: 5173
-              name: ssr
-              protocol: TCP
-          resources: {}
 
       restartPolicy: Always


### PR DESCRIPTION
Removed ssr-report-gen container configuration from the coffee server StatefulSet. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR removes the ssr-report-gen container configuration from the coffee server StatefulSet in the Helm chart, simplifying the deployment by eliminating an unnecessary sidecar container.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes the ssr-report-gen container definition, including its image, environment variables, and port configuration from the StatefulSet template in 001-coffee-server-sts.yaml.</li>

</ul>
</details>

</div>