### PR TITLE
Opl 14808

### DIFF
--- a/apica-ascent/charts/flash-coffee/templates/001-coffee-server-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/001-coffee-server-sts.yaml
@@ -351,18 +351,4 @@ spec:
           resources:
             {{- toYaml .Values.coffee.resources | nindent 12 }}
           {{- end }}
-        - name: ssr-report-gen
-          image: {{ .Values.global.imageRegistry}}/logiqai/ssr-server:v12
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: SSR_HOST
-              value: 0.0.0.0
-            - name: __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS
-              value: coffee
-          ports:
-            - containerPort: 5173
-              name: ssr
-              protocol: TCP
-          resources: {}
-
       restartPolicy: Always

--- a/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
@@ -281,16 +281,16 @@ spec:
           resources: {{- toYaml .Values.coffee_worker.resources | nindent 12 }}
           {{- end }}
         - name: ssr-report-gen
-+          image: {{ .Values.global.imageRegistry}}/logiqai/ssr-server:ssr-v16.0.1-fc1
-+          imagePullPolicy: IfNotPresent
-+          env:
-+            - name: SSR_HOST
-+              value: 0.0.0.0
-+            - name: __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS
-+              value: coffee
-+          ports:
-+            - containerPort: 5173
-+              name: ssr
-+              protocol: TCP
-+          resources: {}
+          image: {{ .Values.global.imageRegistry}}/logiqai/ssr-server:ssr-v16.0.1-fc1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SSR_HOST
+              value: 0.0.0.0
+            - name: __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS
+              value: coffee
+          ports:
+            - containerPort: 5173
+              name: ssr
+              protocol: TCP
+          resources: {}
       restartPolicy: Always

--- a/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
@@ -281,7 +281,7 @@ spec:
           resources: {{- toYaml .Values.coffee_worker.resources | nindent 12 }}
           {{- end }}
         - name: ssr-report-gen
-          image: {{ .Values.global.imageRegistry}}/logiqai/ssr-server:ssr-v16.0.1-fc1
+          image: {{ .Values.global.imageRegistry}}/logiqai/ssr-server:ssr-v16.0.1-fc2
           imagePullPolicy: IfNotPresent
           env:
             - name: SSR_HOST

--- a/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
@@ -280,4 +280,17 @@ spec:
           {{- if .Values.coffee_worker.resources }}
           resources: {{- toYaml .Values.coffee_worker.resources | nindent 12 }}
           {{- end }}
+        - name: ssr-report-gen
++          image: {{ .Values.global.imageRegistry}}/logiqai/ssr-server:ssr-v16.0.1-fc1
++          imagePullPolicy: IfNotPresent
++          env:
++            - name: SSR_HOST
++              value: 0.0.0.0
++            - name: __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS
++              value: coffee
++          ports:
++            - containerPort: 5173
++              name: ssr
++              protocol: TCP
++          resources: {}
       restartPolicy: Always


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request relocates the ssr-report-gen container from the coffee-server StatefulSet to the coffee-worker StatefulSet in the flash-coffee Helm chart, while also updating the container's image to a newer version ssr-v16.0.1-fc2.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes the ssr-report-gen container from the coffee-server StatefulSet in 001-coffee-server-sts.yaml.</li>

<li>Adds the ssr-report-gen container to the coffee-worker StatefulSet in 003-coffee-worker-sts.yaml.</li>

<li>Updates the ssr-report-gen container image from v12 to ssr-v16.0.1-fc2 in 003-coffee-worker-sts.yaml.</li>

</ul>
</details>

</div>