### PR TITLE
SO-8994 updating the metrics endpoint

### DIFF
--- a/apica-ascent/templates/httproute.yaml
+++ b/apica-ascent/templates/httproute.yaml
@@ -114,7 +114,7 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: /api/v1/receive
+        value: /v1/receive/prometheus
     backendRefs:
       - group: ''
         kind: Service


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates the metrics endpoint path in the HTTPRoute configuration to standardize the remote-write receive path for Thanos, aligning it with the existing Prometheus endpoint.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates the path value for Thanos remote-write receive endpoint from "/api/v1/receive" to "/v1/receive/prometheus" in httproute.yaml.</li>

<li>Ensures consistency between Prometheus and Thanos metrics ingestion paths.</li>

</ul>
</details>

</div>