### PR TITLE
SO-9642 Increase the envoy data plane replicas to 4

### DIFF
--- a/apica-ascent/templates/envoy-envoyproxy.yaml
+++ b/apica-ascent/templates/envoy-envoyproxy.yaml
@@ -22,15 +22,6 @@ spec:
             spec:
               template:
                 spec:
-                  topologySpreadConstraints:
-                    - maxSkew: 1
-                      topologyKey: kubernetes.io/hostname
-                      whenUnsatisfiable: ScheduleAnyway
-                      labelSelector:
-                        matchLabels:
-                          app.kubernetes.io/name: envoy
-                          app.kubernetes.io/component: proxy
-                          gateway.envoyproxy.io/owning-gateway-name: {{ .Release.Name }}-gateway
                   affinity:
                     podAntiAffinity:
                       preferredDuringSchedulingIgnoredDuringExecution:

--- a/apica-ascent/templates/envoy-envoyproxy.yaml
+++ b/apica-ascent/templates/envoy-envoyproxy.yaml
@@ -16,6 +16,33 @@ spec:
     kubernetes:
       envoyDeployment:
         replicas: {{ .Values.envoyGateway.envoyProxy.provider.deployment.replicaCount | default 2 }}
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  topologySpreadConstraints:
+                    - maxSkew: 1
+                      topologyKey: kubernetes.io/hostname
+                      whenUnsatisfiable: ScheduleAnyway
+                      labelSelector:
+                        matchLabels:
+                          app.kubernetes.io/name: envoy
+                          app.kubernetes.io/component: proxy
+                          gateway.envoyproxy.io/owning-gateway-name: {{ .Release.Name }}-gateway
+                  affinity:
+                    podAntiAffinity:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        - weight: 100
+                          podAffinityTerm:
+                            topologyKey: kubernetes.io/hostname
+                            labelSelector:
+                              matchLabels:
+                                app.kubernetes.io/name: envoy
+                                app.kubernetes.io/component: proxy
+                                gateway.envoyproxy.io/owning-gateway-name: {{ .Release.Name }}-gateway
+
       envoyService:
         type: {{ .Values.envoyGateway.envoyProxy.provider.service.type | default "LoadBalancer" }}
         {{- if .Values.envoyGateway.envoyProxy.provider.service.annotations }}
@@ -31,5 +58,4 @@ spec:
           value:
             spec:
               externalTrafficPolicy: {{ .Values.envoyGateway.envoyProxy.provider.service.externalTrafficPolicy | default "Cluster" }}
-  
 {{- end }}

--- a/apica-ascent/templates/envoy-envoyproxy.yaml
+++ b/apica-ascent/templates/envoy-envoyproxy.yaml
@@ -14,6 +14,8 @@ spec:
   provider:
     type: {{ .Values.envoyGateway.envoyProxy.provider.type | default "Kubernetes" }}
     kubernetes:
+      envoyDeployment:
+        replicas: {{ .Values.envoyGateway.envoyProxy.provider.deployment.replicaCount | default 2 }}
       envoyService:
         type: {{ .Values.envoyGateway.envoyProxy.provider.service.type | default "LoadBalancer" }}
         {{- if .Values.envoyGateway.envoyProxy.provider.service.annotations }}

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -330,6 +330,8 @@ envoyGateway:
   envoyProxy:
     provider:
       type: Kubernetes
+      deployment:
+        replicaCount: 4
       service:
         type: LoadBalancer
         # OCI Load Balancer annotations


### PR DESCRIPTION
Also add an anti-affinity rule to try to keep the pods scheduled on different nodes 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request increases the replica count for the Envoy data plane from the default of 2 to 4 and introduces pod anti-affinity rules to promote distribution of Envoy proxy pods across different Kubernetes nodes, enhancing availability and load distribution.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds replicaCount configuration set to 4 in values.yaml for the Envoy proxy deployment.</li>

<li>Introduces envoyDeployment section in the EnvoyProxy template with replicas and anti-affinity patch.</li>

<li>The anti-affinity uses preferredDuringSchedulingIgnoredDuringExecution with weight 100 and topologyKey kubernetes.io/hostname to avoid scheduling on the same node.</li>

</ul>
</details>

</div>