### PR TITLE
SO-9486 Support internal/custom S3 deployments

### DIFF
--- a/apica-ascent/Chart.yaml
+++ b/apica-ascent/Chart.yaml
@@ -38,11 +38,6 @@ dependencies:
     name: redis
     repository: https://charts.bitnami.com/bitnami
     version: 10.6.5
-  - alias: s3gateway
-    condition: global.chart.s3gateway
-    name: minio
-    repository: https://kubernetes-charts.storage.googleapis.com
-    version: 5.0.20
   - alias: prometheus
     condition: global.chart.prometheus
     name: kube-prometheus

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -118,10 +118,10 @@ spec:
               - key: ca_chain
                 path: ca.crt
         {{- end }}
-        {{- if .Values.global.environment.s3_custom_ca }}
+        {{- if .Values.global.environment.s3_custom_ca.enabled }}
         - name: s3-custom-ca
           configMap:
-            name: s3-custom-ca
+            name: {{ .Values.global.environment.s3_custom_ca.map_name }}
         {{- end }}
       {{ if .Values.podPerNode }}
       affinity:
@@ -265,7 +265,7 @@ spec:
           - mountPath: /flash/sharedcerts
             name: sharedcert
           {{ end }}
-          {{- if .Values.global.environment.s3_custom_ca }}
+          {{- if .Values.global.environment.s3_custom_ca.enabled }}
           - mountPath: /etc/ssl/certs/s3-custom-ca.crt
             name: s3-custom-ca
             subPath: s3-custom-ca.crt
@@ -473,7 +473,7 @@ spec:
           - mountPath: /flash/sharedcerts
             name: sharedcert
           {{ end }}
-          {{- if .Values.global.environment.s3_custom_ca }}
+          {{- if .Values.global.environment.s3_custom_ca.enabled }}
           - mountPath: /etc/ssl/certs/s3-custom-ca.crt
             name: s3-custom-ca
             subPath: s3-custom-ca.crt

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -118,6 +118,11 @@ spec:
               - key: ca_chain
                 path: ca.crt
         {{- end }}
+        {{- if .Values.global.environment.s3_custom_ca }}
+        - name: s3-custom-ca
+          configMap:
+            name: s3-custom-ca
+        {{- end }}
       {{ if .Values.podPerNode }}
       affinity:
         podAntiAffinity:
@@ -260,6 +265,11 @@ spec:
           - mountPath: /flash/sharedcerts
             name: sharedcert
           {{ end }}
+          {{- if .Values.global.environment.s3_custom_ca }}
+          - mountPath: /etc/ssl/certs/s3-custom-ca.crt
+            name: s3-custom-ca
+            subPath: s3-custom-ca.crt
+          {{- end }}
           ports:
             - name: grpc
               containerPort: 50054
@@ -463,6 +473,11 @@ spec:
           - mountPath: /flash/sharedcerts
             name: sharedcert
           {{ end }}
+          {{- if .Values.global.environment.s3_custom_ca }}
+          - mountPath: /etc/ssl/certs/s3-custom-ca.crt
+            name: s3-custom-ca
+            subPath: s3-custom-ca.crt
+          {{- end }}
           resources:
 {{ toYaml .Values.resources.sidecarQuery | indent 12 }}
         - name: {{ .Chart.Name }}-tracing

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -474,9 +474,9 @@ spec:
             name: sharedcert
           {{ end }}
           {{- if .Values.global.environment.s3_custom_ca.enabled }}
-          - mountPath: /etc/ssl/certs/s3-custom-ca.crt
+          - mountPath: /etc/ssl/certs/ca.crt
             name: s3-custom-ca
-            subPath: s3-custom-ca.crt
+            subPath: ca.crt
           {{- end }}
           resources:
 {{ toYaml .Values.resources.sidecarQuery | indent 12 }}

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -266,9 +266,9 @@ spec:
             name: sharedcert
           {{ end }}
           {{- if .Values.global.environment.s3_custom_ca.enabled }}
-          - mountPath: /etc/ssl/certs/s3-custom-ca.crt
+          - mountPath: /etc/ssl/certs/ca.crt
             name: s3-custom-ca
-            subPath: s3-custom-ca.crt
+            subPath: ca.crt
           {{- end }}
           ports:
             - name: grpc

--- a/apica-ascent/values.large.yaml
+++ b/apica-ascent/values.large.yaml
@@ -407,10 +407,13 @@ global:
     s3_url: '##YOUR_S3_URL##'
     s3_access: '##YOUR_S3_ACCESS_KEY##'
     s3_secret: '##YOUR_S3_ACCESS_SECRET##'
-    AWS_ACCESS_KEY_ID: '##YOUR_S3_ACCESS_KEY##'
-    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_KEY##'
     s3_bucket: '##YOUR_S3_BUCKET##'
     s3_region: '##YOUR_S3_REGION##'
+    s3_custom_ca:
+      enabled: false
+      map_name: kube-root-ca.crt
+    AWS_ACCESS_KEY_ID: '##YOUR_S3_ACCESS_KEY##'
+    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_KEY##'
     admin_name: '##ADMIN_ACCOUNT_NAME##'
     admin_password: '##ADMIN_ACCOUNT_PASSWORD##'
     admin_org: '##ADMIN_ORGANIZATION##'

--- a/apica-ascent/values.large.yaml
+++ b/apica-ascent/values.large.yaml
@@ -199,36 +199,6 @@ flash-coffee:
         cpu: 100m
       limits:
         memory: 2000Mi
-s3gateway:
-  s3gateway:
-    enabled: false
-  mode: distributed
-  image:
-    repository: minio/minio
-    tag: RELEASE.2020-09-17T04-49-20Z
-  defaultBucket:
-    enabled: true
-  fullnameOverride: s3-gateway
-  accessKey: not-needed
-  secretKey: not-needed
-  metrics:
-    serviceMonitor:
-      enabled: false
-  buckets:
-  - name: devops-test
-    policy: none
-    purge: false
-  persistence:
-    enabled: true
-    size: 25Gi
-  securityContext:
-    enabled: true
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
-  serviceAccount:
-    create: true
-    name: s3-gateway
 thanos:
   createObjstoreSecret: true
   receive:

--- a/apica-ascent/values.medium.yaml
+++ b/apica-ascent/values.medium.yaml
@@ -407,10 +407,13 @@ global:
     s3_url: '##YOUR_S3_URL##'
     s3_access: '##YOUR_S3_ACCESS_KEY##'
     s3_secret: '##YOUR_S3_ACCESS_SECRET##'
-    AWS_ACCESS_KEY_ID: '##YOUR_S3_ACCESS_KEY##'
-    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_KEY##'
     s3_bucket: '##YOUR_S3_BUCKET##'
     s3_region: '##YOUR_S3_REGION##'
+    s3_custom_ca:
+      enabled: false
+      map_name: kube-root-ca.crt
+    AWS_ACCESS_KEY_ID: '##YOUR_S3_ACCESS_KEY##'
+    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_KEY##'
     admin_name: '##ADMIN_ACCOUNT_NAME##'
     admin_password: '##ADMIN_ACCOUNT_PASSWORD##'
     admin_org: '##ADMIN_ORGANIZATION##'

--- a/apica-ascent/values.medium.yaml
+++ b/apica-ascent/values.medium.yaml
@@ -199,36 +199,6 @@ flash-coffee:
         cpu: 100m
       limits:
         memory: 2000Mi
-s3gateway:
-  s3gateway:
-    enabled: false
-  mode: distributed
-  image:
-    repository: minio/minio
-    tag: RELEASE.2020-09-17T04-49-20Z
-  defaultBucket:
-    enabled: true
-  fullnameOverride: s3-gateway
-  accessKey: not-needed
-  secretKey: not-needed
-  metrics:
-    serviceMonitor:
-      enabled: false
-  buckets:
-  - name: devops-test
-    policy: none
-    purge: false
-  persistence:
-    enabled: true
-    size: 25Gi
-  securityContext:
-    enabled: true
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
-  serviceAccount:
-    create: true
-    name: s3-gateway
 thanos:
   createObjstoreSecret: true
   receive:

--- a/apica-ascent/values.single.yaml
+++ b/apica-ascent/values.single.yaml
@@ -407,10 +407,13 @@ global:
     s3_url: '##YOUR_S3_URL##'
     s3_access: '##YOUR_S3_ACCESS_KEY##'
     s3_secret: '##YOUR_S3_ACCESS_SECRET##'
-    AWS_ACCESS_KEY_ID: '##YOUR_S3_ACCESS_KEY##'
-    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_KEY##'
     s3_bucket: '##YOUR_S3_BUCKET##'
     s3_region: '##YOUR_S3_REGION##'
+    s3_custom_ca:
+      enabled: false
+      map_name: kube-root-ca.crt
+    AWS_ACCESS_KEY_ID: '##YOUR_S3_ACCESS_KEY##'
+    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_KEY##'
     admin_name: '##ADMIN_ACCOUNT_NAME##'
     admin_password: '##ADMIN_ACCOUNT_PASSWORD##'
     admin_org: '##ADMIN_ORGANIZATION##'

--- a/apica-ascent/values.single.yaml
+++ b/apica-ascent/values.single.yaml
@@ -199,36 +199,6 @@ flash-coffee:
         cpu: 100m
       limits:
         memory: 2000Mi
-s3gateway:
-  s3gateway:
-    enabled: false
-  mode: distributed
-  image:
-    repository: minio/minio
-    tag: RELEASE.2020-09-17T04-49-20Z
-  defaultBucket:
-    enabled: true
-  fullnameOverride: s3-gateway
-  accessKey: not-needed
-  secretKey: not-needed
-  metrics:
-    serviceMonitor:
-      enabled: false
-  buckets:
-  - name: devops-test
-    policy: none
-    purge: false
-  persistence:
-    enabled: true
-    size: 25Gi
-  securityContext:
-    enabled: true
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
-  serviceAccount:
-    create: true
-    name: s3-gateway
 thanos:
   createObjstoreSecret: true
   receive:

--- a/apica-ascent/values.small.yaml
+++ b/apica-ascent/values.small.yaml
@@ -407,10 +407,13 @@ global:
     s3_url: '##YOUR_S3_URL##'
     s3_access: '##YOUR_S3_ACCESS_KEY##'
     s3_secret: '##YOUR_S3_ACCESS_SECRET##'
-    AWS_ACCESS_KEY_ID: '##YOUR_S3_ACCESS_KEY##'
-    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_KEY##'
     s3_bucket: '##YOUR_S3_BUCKET##'
     s3_region: '##YOUR_S3_REGION##'
+    s3_custom_ca:
+      enabled: false
+      map_name: kube-root-ca.crt
+    AWS_ACCESS_KEY_ID: '##YOUR_S3_ACCESS_KEY##'
+    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_KEY##'
     admin_name: '##ADMIN_ACCOUNT_NAME##'
     admin_password: '##ADMIN_ACCOUNT_PASSWORD##'
     admin_org: '##ADMIN_ORGANIZATION##'

--- a/apica-ascent/values.small.yaml
+++ b/apica-ascent/values.small.yaml
@@ -199,36 +199,6 @@ flash-coffee:
         cpu: 100m
       limits:
         memory: 2000Mi
-s3gateway:
-  s3gateway:
-    enabled: false
-  mode: distributed
-  image:
-    repository: minio/minio
-    tag: RELEASE.2020-09-17T04-49-20Z
-  defaultBucket:
-    enabled: true
-  fullnameOverride: s3-gateway
-  accessKey: not-needed
-  secretKey: not-needed
-  metrics:
-    serviceMonitor:
-      enabled: false
-  buckets:
-  - name: devops-test
-    policy: none
-    purge: false
-  persistence:
-    enabled: true
-    size: 25Gi
-  securityContext:
-    enabled: true
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
-  serviceAccount:
-    create: true
-    name: s3-gateway
 thanos:
   createObjstoreSecret: true
   receive:

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -205,37 +205,6 @@ flash-coffee:
       limits:
         memory: 2000Mi
 
-s3gateway:
-  s3gateway:
-    enabled: false
-  mode: distributed
-  image:
-    repository: minio/minio
-    tag: RELEASE.2020-09-17T04-49-20Z
-  defaultBucket:
-    enabled: true
-  fullnameOverride: s3-gateway
-  accessKey: not-needed
-  secretKey: not-needed
-  metrics:
-    serviceMonitor:
-      enabled: false
-  buckets:
-    - name: devops-test
-      policy: none
-      purge: false
-  persistence:
-    enabled: true
-    size: 25Gi
-  securityContext:
-    enabled: true
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
-  serviceAccount:
-    create: true
-    name: s3-gateway
-
 thanos:
   createObjstoreSecret: true
   receive:

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -457,10 +457,13 @@ global:
     s3_url: "https://<bucket-namespace>.compat.objectstorage.<region>.oraclecloud.com"
     s3_access: "s3_access"
     s3_secret: "s3_secret"
-    AWS_ACCESS_KEY_ID: "s3_access"
-    AWS_SECRET_ACCESS_KEY: "s3_secret"
     s3_bucket: "bucket-name"
     s3_region: "region"
+    s3_custom_ca:
+      enabled: false
+      map_name: "kube-root-ca.crt"
+    AWS_ACCESS_KEY_ID: "s3_access"
+    AWS_SECRET_ACCESS_KEY: "s3_secret"
     admin_name: "devops@apica.io"
     admin_password: "password"
     admin_org: "flash-org"


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates the Apica Ascent Helm chart to support internal or custom S3 deployments by removing the bundled MinIO S3 gateway and adding support for custom certificate authorities.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removed s3gateway dependency from Chart.yaml to eliminate reliance on bundled MinIO.</li>

<li>Removed s3gateway configuration blocks from all values files.</li>

<li>Added s3_custom_ca configuration in global environment across all values files.</li>

<li>Updated StatefulSet template to conditionally mount custom CA certificate for secure S3 connections.</li>

</ul>
</details>

</div>