### PR TITLE
SO-9657 Disable cluster wide metrics

### DIFF
--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -412,17 +412,39 @@ prometheus:
   operator:
     enabled: true
     replicaCount: 1
+    kubeletService:
+      enabled: false
   kube-state-metrics:
-    replicaCount: 1
-  # Disable node-exporter via exporters section
+    serviceMonitor:
+      enabled: false
+  node-exporter:
+    serviceMonitor:
+      enabled: false
+  kubeApiServer:
+    enabled: false
+  kubeControllerManager:
+    enabled: false
+    service:
+      enabled: false
+  kubeScheduler:
+    enabled: false
+    service:
+      enabled: false
+  kubelet:
+    enabled: false
+  coreDns:
+    enabled: false
+    service:
+      enabled: false
+  kubeProxy:
+    enabled: false
+    service:
+      enabled: false
   exporters:
     node-exporter:
       enabled: false
     kube-state-metrics:
-      enabled: true
-  node-exporter:
-    enabled: false
-    replicaCount: 0
+      enabled: false
 
 grafana:
   fullnameOverride: grafana


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR disables cluster-wide metrics collection in the Prometheus deployment by modifying the Helm values configuration to turn off monitoring for various Kubernetes infrastructure components and exporters.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Disables service monitors for kube-state-metrics and node-exporter in values.yaml</li>

<li>Sets enabled to false for monitoring of Kubernetes API server, controller manager, scheduler, kubelet, coreDNS, and kube-proxy</li>

<li>Disables the node-exporter and kube-state-metrics exporters</li>

</ul>
</details>

</div>