### PR TITLE
2.16.1

### DIFF
--- a/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
@@ -283,7 +283,7 @@ spec:
           resources: {{- toYaml .Values.coffee_worker.resources | nindent 12 }}
           {{- end }}
         - name: ssr-report-gen
-          image: {{ .Values.global.imageRegistry}}/logiqai/ssr-server:ssr-v16.0.1
+          image: {{ .Values.global.imageRegistry}}/logiqai/ssr-server:ssr-v16.0.2
           imagePullPolicy: IfNotPresent
           env:
             - name: SSR_HOST

--- a/apica-ascent/values.large.yaml
+++ b/apica-ascent/values.large.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.21.0
+    tag: v3.21.1
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.22.0
+      tag: v3.22.1
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 4
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.22.0
+      tag: v3.22.1
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.medium.yaml
+++ b/apica-ascent/values.medium.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.21.0
+    tag: v3.21.1
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.22.0
+      tag: v3.22.1
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 3
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.22.0
+      tag: v3.22.1
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.single.yaml
+++ b/apica-ascent/values.single.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.21.0
+    tag: v3.21.1
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 1
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.22.0
+      tag: v3.22.1
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 1
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.22.0
+      tag: v3.22.1
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.small.yaml
+++ b/apica-ascent/values.small.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.21.0
+    tag: v3.21.1
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.22.0
+      tag: v3.22.1
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.22.0
+      tag: v3.22.1
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.21.0
+    tag: v3.21.1
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -184,7 +184,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.22.0
+      tag: v3.22.1
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -196,7 +196,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: brew.v3.22.0
+      tag: v3.22.1
       pullPolicy: IfNotPresent
     resources:
       requests:


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request updates image versions for several components in the Apica Ascent Helm chart, including logiq-flash, flash-brew-coffee, and ssr-server, to their latest releases across different deployment configurations.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates logiq-flash image tag from v3.21.0 to v3.21.1 in values.yaml</li>

<li>Updates flash-brew-coffee image tag from brew.v3.22.0 to v3.22.1 in flash-coffee sections across all value files</li>

<li>Updates ssr-server image tag from ssr-v16.0.1 to ssr-v16.0.2 in 003-coffee-worker-sts.yaml template</li>

</ul>
</details>

</div>