### PR TITLE
Fix copy-paste error in update script

### DIFF
--- a/apica-ascent/update-onprem-values.pl
+++ b/apica-ascent/update-onprem-values.pl
@@ -58,7 +58,7 @@ foreach my $size (@tshirts) {
     $clone->{global}{environment}{s3_bucket}             = '##YOUR_S3_BUCKET##';
     $clone->{global}{environment}{s3_region}             = '##YOUR_S3_REGION##';
     $clone->{global}{environment}{AWS_ACCESS_KEY_ID}     = '##YOUR_S3_ACCESS_KEY##';
-    $clone->{global}{environment}{AWS_SECRET_ACCESS_KEY} = '##YOUR_S3_ACCESS_KEY##';
+    $clone->{global}{environment}{AWS_SECRET_ACCESS_KEY} = '##YOUR_S3_ACCESS_SECRET##';
     $clone->{global}{environment}{awsServiceEndpoint}    = '##YOUR_S3_URL##';
     $clone->{global}{environment}{admin_name}            = '##ADMIN_ACCOUNT_NAME##';
     $clone->{global}{environment}{admin_password}        = '##ADMIN_ACCOUNT_PASSWORD##';

--- a/apica-ascent/values.large.yaml
+++ b/apica-ascent/values.large.yaml
@@ -353,16 +353,39 @@ prometheus:
   operator:
     enabled: true
     replicaCount: 1
+    kubeletService:
+      enabled: false
   kube-state-metrics:
-    replicaCount: 1
+    serviceMonitor:
+      enabled: false
+  node-exporter:
+    serviceMonitor:
+      enabled: false
+  kubeApiServer:
+    enabled: false
+  kubeControllerManager:
+    enabled: false
+    service:
+      enabled: false
+  kubeScheduler:
+    enabled: false
+    service:
+      enabled: false
+  kubelet:
+    enabled: false
+  coreDns:
+    enabled: false
+    service:
+      enabled: false
+  kubeProxy:
+    enabled: false
+    service:
+      enabled: false
   exporters:
     node-exporter:
       enabled: false
     kube-state-metrics:
-      enabled: true
-  node-exporter:
-    enabled: false
-    replicaCount: 0
+      enabled: false
 grafana:
   fullnameOverride: grafana
 logiqctl:
@@ -431,7 +454,7 @@ global:
       enabled: false
       map_name: kube-root-ca.crt
     AWS_ACCESS_KEY_ID: '##YOUR_S3_ACCESS_KEY##'
-    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_KEY##'
+    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_SECRET##'
     admin_name: '##ADMIN_ACCOUNT_NAME##'
     admin_password: '##ADMIN_ACCOUNT_PASSWORD##'
     admin_org: '##ADMIN_ORGANIZATION##'

--- a/apica-ascent/values.medium.yaml
+++ b/apica-ascent/values.medium.yaml
@@ -353,16 +353,39 @@ prometheus:
   operator:
     enabled: true
     replicaCount: 1
+    kubeletService:
+      enabled: false
   kube-state-metrics:
-    replicaCount: 1
+    serviceMonitor:
+      enabled: false
+  node-exporter:
+    serviceMonitor:
+      enabled: false
+  kubeApiServer:
+    enabled: false
+  kubeControllerManager:
+    enabled: false
+    service:
+      enabled: false
+  kubeScheduler:
+    enabled: false
+    service:
+      enabled: false
+  kubelet:
+    enabled: false
+  coreDns:
+    enabled: false
+    service:
+      enabled: false
+  kubeProxy:
+    enabled: false
+    service:
+      enabled: false
   exporters:
     node-exporter:
       enabled: false
     kube-state-metrics:
-      enabled: true
-  node-exporter:
-    enabled: false
-    replicaCount: 0
+      enabled: false
 grafana:
   fullnameOverride: grafana
 logiqctl:
@@ -431,7 +454,7 @@ global:
       enabled: false
       map_name: kube-root-ca.crt
     AWS_ACCESS_KEY_ID: '##YOUR_S3_ACCESS_KEY##'
-    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_KEY##'
+    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_SECRET##'
     admin_name: '##ADMIN_ACCOUNT_NAME##'
     admin_password: '##ADMIN_ACCOUNT_PASSWORD##'
     admin_org: '##ADMIN_ORGANIZATION##'

--- a/apica-ascent/values.single.yaml
+++ b/apica-ascent/values.single.yaml
@@ -353,16 +353,39 @@ prometheus:
   operator:
     enabled: true
     replicaCount: 1
+    kubeletService:
+      enabled: false
   kube-state-metrics:
-    replicaCount: 1
+    serviceMonitor:
+      enabled: false
+  node-exporter:
+    serviceMonitor:
+      enabled: false
+  kubeApiServer:
+    enabled: false
+  kubeControllerManager:
+    enabled: false
+    service:
+      enabled: false
+  kubeScheduler:
+    enabled: false
+    service:
+      enabled: false
+  kubelet:
+    enabled: false
+  coreDns:
+    enabled: false
+    service:
+      enabled: false
+  kubeProxy:
+    enabled: false
+    service:
+      enabled: false
   exporters:
     node-exporter:
       enabled: false
     kube-state-metrics:
-      enabled: true
-  node-exporter:
-    enabled: false
-    replicaCount: 0
+      enabled: false
 grafana:
   fullnameOverride: grafana
 logiqctl:
@@ -431,7 +454,7 @@ global:
       enabled: false
       map_name: kube-root-ca.crt
     AWS_ACCESS_KEY_ID: '##YOUR_S3_ACCESS_KEY##'
-    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_KEY##'
+    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_SECRET##'
     admin_name: '##ADMIN_ACCOUNT_NAME##'
     admin_password: '##ADMIN_ACCOUNT_PASSWORD##'
     admin_org: '##ADMIN_ORGANIZATION##'

--- a/apica-ascent/values.small.yaml
+++ b/apica-ascent/values.small.yaml
@@ -353,16 +353,39 @@ prometheus:
   operator:
     enabled: true
     replicaCount: 1
+    kubeletService:
+      enabled: false
   kube-state-metrics:
-    replicaCount: 1
+    serviceMonitor:
+      enabled: false
+  node-exporter:
+    serviceMonitor:
+      enabled: false
+  kubeApiServer:
+    enabled: false
+  kubeControllerManager:
+    enabled: false
+    service:
+      enabled: false
+  kubeScheduler:
+    enabled: false
+    service:
+      enabled: false
+  kubelet:
+    enabled: false
+  coreDns:
+    enabled: false
+    service:
+      enabled: false
+  kubeProxy:
+    enabled: false
+    service:
+      enabled: false
   exporters:
     node-exporter:
       enabled: false
     kube-state-metrics:
-      enabled: true
-  node-exporter:
-    enabled: false
-    replicaCount: 0
+      enabled: false
 grafana:
   fullnameOverride: grafana
 logiqctl:
@@ -431,7 +454,7 @@ global:
       enabled: false
       map_name: kube-root-ca.crt
     AWS_ACCESS_KEY_ID: '##YOUR_S3_ACCESS_KEY##'
-    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_KEY##'
+    AWS_SECRET_ACCESS_KEY: '##YOUR_S3_ACCESS_SECRET##'
     admin_name: '##ADMIN_ACCOUNT_NAME##'
     admin_password: '##ADMIN_ACCOUNT_PASSWORD##'
     admin_org: '##ADMIN_ORGANIZATION##'


### PR DESCRIPTION
Sync onprem examples 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request addresses a copy-paste error in the update script for on-premises values and synchronizes the example configurations by correcting AWS credentials and disabling unnecessary monitoring components in Prometheus.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Fixes a copy-paste error in update-onprem-values.pl where AWS_SECRET_ACCESS_KEY was incorrectly set to the same value as AWS_ACCESS_KEY_ID, and applies the same correction to the global environment section in values.large.yaml, values.medium.yaml, values.single.yaml, and values.small.yaml.</li>

<li>Disables various Prometheus monitoring services and exporters in values.large.yaml, values.medium.yaml, values.single.yaml, and values.small.yaml, including kubeletService, serviceMonitors for kube-state-metrics and node-exporter, and core Kubernetes components like kubeApiServer, kubeControllerManager, kubeScheduler, kubelet, coreDns, and kubeProxy.</li>

</ul>
</details>

</div>