### PR TITLE
granted storage class access to logiq-flash service account

### DIFF
--- a/apica-ascent/Chart.yaml
+++ b/apica-ascent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 3.1.1
+version: 3.1.2
 appVersion: v2.16.1
 description: Apica Ascent - Cloud-native observability platform
 keywords:

--- a/apica-ascent/charts/logiq-flash/templates/clusterrole.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/clusterrole.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "logiq-flash.fullname" . }}
+  labels:
+    app: {{ template "logiq-flash.name" . }}
+    chart: {{ template "logiq-flash.chart" . }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/apica-ascent/charts/logiq-flash/templates/clusterrolebinding.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "logiq-flash.fullname" . }}
+  labels:
+    app: {{ template "logiq-flash.name" . }}
+    chart: {{ template "logiq-flash.chart" . }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "logiq-flash.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: logiq-flash
+  namespace: {{ .Release.Namespace }}

--- a/apica-ascent/charts/logiq-flash/templates/role.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/role.yaml
@@ -63,24 +63,6 @@ rules:
   - patch
   - update
 
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - get
-  - list
-  - watch
-
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-
 # Application workloads (namespace-scoped)
 - apiGroups:
   - apps

--- a/apica-ascent/charts/logiq-flash/templates/role.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/role.yaml
@@ -63,6 +63,24 @@ rules:
   - patch
   - update
 
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+
 # Application workloads (namespace-scoped)
 - apiGroups:
   - apps


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR refactors the RBAC configuration for the logiq-flash component in the apica-ascent Helm chart by introducing a ClusterRole and ClusterRoleBinding to grant cluster-wide access to storage-related Kubernetes resources, allowing the service account to manage persistent volumes and storage classes, while removing these permissions from the namespaced Role to avoid duplication and ensure proper scope alignment. Additionally, the chart version is updated from 3.1.1 to 3.1.2.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds a new ClusterRole in clusterrole.yaml with permissions to get, list, and watch persistentvolumes and storageclasses, enabling cluster-wide storage resource access for the logiq-flash service account.</li>

<li>Creates a ClusterRoleBinding in clusterrolebinding.yaml to bind the ClusterRole to the logiq-flash service account in the release namespace.</li>

<li>Removes storage-related permissions from the namespaced Role in role.yaml to eliminate redundancy and align with the new cluster-scoped access model.</li>

<li>Updates the chart version from 3.1.1 to 3.1.2 in Chart.yaml.</li>

</ul>
</details>

</div>