### PR TITLE
SO-9420 STS HA features

### DIFF
--- a/apica-ascent/charts/flash-coffee/templates/001-coffee-server-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/001-coffee-server-sts.yaml
@@ -11,33 +11,21 @@ spec:
   selector:
     matchLabels:
       app: coffee-server
-
-  # ── Feature 4 ── Rolling update: only 1 pod unavailable at a time.
-  # StatefulSet updates proceed pod-by-pod (highest ordinal first).
-  # The readinessProbe below gates traffic so old pods keep serving
-  # until the new pod is fully ready.
+  # Rolling update: 1 pod down at a time; readinessProbe gates traffic during rollout.
   updateStrategy:
     type: {{ .Values.coffee.updateStrategy.type }}
     rollingUpdate:
       maxUnavailable: {{ .Values.coffee.updateStrategy.maxUnavailable }}
-
   template:
     metadata:
       labels:
         app: coffee-server
     spec:
       serviceAccountName: flash-coffee
-
-      # ── Feature 5 ── Graceful shutdown budget.
-      # Kubernetes removes the pod from endpoints and sends SIGTERM simultaneously.
-      # The preStop sleep gives the load-balancer time to drain connections before
-      # the process receives SIGTERM. terminationGracePeriodSeconds is the hard
-      # ceiling for the entire shutdown sequence (preStop + SIGTERM handling).
+      # preStop(15s) fills the LB-drain gap before SIGTERM; 60s is the hard ceiling.
       terminationGracePeriodSeconds: {{ .Values.coffee.terminationGracePeriodSeconds }}
 
-      # ── Feature 1 ── Topology spread constraints (soft, ScheduleAnyway).
-      # Two constraints: spread across hostnames (nodes) AND across zones.
-      # ScheduleAnyway means a pod is never left Pending due to topology skew.
+      # Soft spread across nodes and zones — ScheduleAnyway never blocks scheduling.
       {{- if .Values.coffee.topologySpreadConstraints.enabled }}
       topologySpreadConstraints:
         - maxSkew: {{ .Values.coffee.topologySpreadConstraints.maxSkew }}
@@ -56,7 +44,6 @@ spec:
 
       affinity:
         {{- if .Values.global.nodeSelectors.enabled }}
-        # Node affinity: hard requirement to land on the correct node pool.
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -66,12 +53,7 @@ spec:
                     values:
                       - {{ .Values.global.nodeSelectors.other }}
         {{- end }}
-
-        # ── Feature 2 ── Preferred pod anti-affinity (weight 100).
-        # Adds strong scheduling pressure to avoid co-locating replicas on the
-        # same node WITHOUT ever blocking scheduling (preferred, not required).
-        # Never use requiredDuringScheduling here — it causes Pending pods when
-        # nodes < replicas.
+        # Preferred anti-affinity: adds scheduling pressure without ever blocking.
         {{- if .Values.coffee.podAntiAffinity.enabled }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -150,42 +132,30 @@ spec:
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.coffee.image.repository }}:{{ .Values.coffee.image.tag }}"
           imagePullPolicy: {{ .Values.coffee.image.pullPolicy }}
           command: ["/app/flash-brew/setup_coffee.sh"]
-
-          # ── Feature 5 (continued) ── preStop hook.
-          # Sleeps for preStopSleepSeconds before the container receives SIGTERM,
-          # giving the kube-proxy / cloud LB time to remove this pod from the
-          # active endpoint slice and stop routing new requests to it.
+          # Sleep before SIGTERM so the LB stops routing before the process exits.
           lifecycle:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep {{ .Values.coffee.preStopSleepSeconds }}"]
-
           env:
             - name: LOGIQ_UI_GOOGLE_ANALYTICS_CODE
               value: {{ .Values.global.environment.gacode }}
-
             - name: CONFIG_HASH
               value: {{ include "flash-coffee.confighash" . | quote }}
-
             - name: PYTHONUNBUFFERED
               value: "0"
-
             - name: COOKIE_SECRET
               value: d84c0edd-ab5e-4664-b0ee-2cd15a9ae5f0
-
             - name: LOG_LEVEL
               value: ERROR
-
             {{- if .Values.global.environment.parent_host }}
             - name: PARENT_HOST
               value: {{ .Values.global.environment.parent_host }}
             {{- end }}
-
             {{- if .Values.global.domain }}
             - name: HOST
               value: {{ .Values.global.domain }}
             {{- end }}
-
             - name: MY_APP_NAME
               value: coffee-server
             - name: MY_NODE_NAME
@@ -204,99 +174,82 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-
             {{- if .Values.global.environment.cluster_id }}
             - name: MY_CLUSTER_ID
               value: {{ .Values.global.environment.cluster_id }}
             {{- end }}
-
             - name: LOGIQ_FLASH_HOST
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: logiq_flash_host
-
             - name: LOGIQ_FLASH_PORT
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: logiq_flash_port
-
             - name: REDIS_HOST
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: redis_host
-
             - name: REDIS_URL
               value: redis://{{ .Values.global.environment.redis_host }}:{{ .Values.global.environment.redis_port }}/0
-
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: postgres_user
-
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: postgres_password
-
             - name: POSTGRES_HOST
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: postgres_host
-
             - name: POSTGRES_PORT
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: postgres_port
-
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: postgres_db
-
             - name: POSTGRES_COFFEE_DB
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: postgres_coffee_db
-
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: coffee_database_url
-
             - name: S3_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: s3_url
-
             - name: S3_ACCESS
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.sharedSecretName }}
                   key: s3_access
-
             - name: S3_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.sharedSecretName }}
                   key: s3_secret
-
             - name: S3_BUCKET
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.sharedSecretName }}
                   key: s3_bucket
-
             {{- if .Values.global.environment.admin_name }}
             - name: ADMIN_NAME
               valueFrom:
@@ -304,7 +257,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: admin_name
             {{- end }}
-
             {{- if .Values.global.environment.admin_password }}
             - name: ADMIN_PASSWORD
               valueFrom:
@@ -312,7 +264,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: admin_password
             {{- end }}
-
             {{- if .Values.global.environment.admin_org }}
             - name: ADMIN_ORG
               valueFrom:
@@ -320,7 +271,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: admin_org
             {{- end }}
-
             {{- if .Values.global.environment.admin_email }}
             - name: ADMIN_EMAIL
               valueFrom:
@@ -328,7 +278,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: admin_email
             {{- end }}
-
             {{- if .Values.global.environment.mail_server }}
             - name: MAIL_SERVER
               valueFrom:
@@ -336,7 +285,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: mail_server
             {{- end }}
-
             {{- if .Values.global.environment.mail_port }}
             - name: MAIL_PORT
               valueFrom:
@@ -344,7 +292,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: mail_port
             {{- end }}
-
             {{- if .Values.global.environment.mail_username }}
             - name: MAIL_USERNAME
               valueFrom:
@@ -352,7 +299,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: mail_username
             {{- end }}
-
             {{- if .Values.global.environment.mail_password }}
             - name: MAIL_PASSWORD
               valueFrom:
@@ -360,7 +306,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: mail_password
             {{- end }}
-
             {{- if .Values.global.environment.mail_default_sender }}
             - name: MAIL_DEFAULT_SENDER
               valueFrom:
@@ -368,27 +313,20 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: mail_default_sender
             {{- end }}
-
             - name: WEB_WORKERS
               value: "{{ .Values.coffee.web_workers }}"
-
             - name: CONFIGURE_LOGIQ_DS
               value: "true"
-
             - name: COFFEE_UI_SERVER_URL
               value: http://{{ .Values.coffee.name }}:{{ .Values.coffee.port }}
-
             - name: CONFIGURE_LOGIQEVENTS_DS
               value: "false"
-
             {{- if .Values.global.chart.prometheus }}
             - name: PROM_ALERT_MGR_URL
               value: {{ .Release.Name }}-prometheus-alertmanager:9093
             {{- end }}
-
             - name: EVENT_REPORTING_WEBHOOKS
               value: ""
-
             - name: LOGIQ_AUDIT_EVENT_GROUP
               value: logiq-audit
 
@@ -400,13 +338,8 @@ spec:
 
           ports:
             - containerPort: {{ .Values.coffee.targetPort }}
-              name: http
-              protocol: TCP
 
-          # ── Feature 4 (continued) ── Readiness probe gates rollout traffic.
-          # A pod is only added to the endpoint slice (and receives requests)
-          # once this probe succeeds. During a rolling update the old pod keeps
-          # serving until the new pod passes its readiness check.
+          # Readiness gates endpoint inclusion; old pod keeps serving during rollout.
           readinessProbe:
             httpGet:
               port: {{ .Values.coffee.targetPort }}
@@ -417,8 +350,7 @@ spec:
             successThreshold: 1
             failureThreshold: 5
 
-          # Liveness probe: restart the container if port 5000 stops responding.
-          # GET / returns HTTP 200 (frontend HTML) — valid 2xx liveness signal.
+          # Liveness uses GET / (returns 200); restarts if port 5000 stops responding.
           livenessProbe:
             httpGet:
               port: {{ .Values.coffee.targetPort }}

--- a/apica-ascent/charts/flash-coffee/templates/001-coffee-server-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/001-coffee-server-sts.yaml
@@ -4,12 +4,23 @@ metadata:
   labels:
     app: coffee-server-deployment
   name: coffee-server
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.coffee.replicaCount }}
   serviceName: coffee
   selector:
     matchLabels:
       app: coffee-server
+
+  # ── Feature 4 ── Rolling update: only 1 pod unavailable at a time.
+  # StatefulSet updates proceed pod-by-pod (highest ordinal first).
+  # The readinessProbe below gates traffic so old pods keep serving
+  # until the new pod is fully ready.
+  updateStrategy:
+    type: {{ .Values.coffee.updateStrategy.type }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.coffee.updateStrategy.maxUnavailable }}
+
   template:
     metadata:
       labels:
@@ -17,8 +28,35 @@ spec:
     spec:
       serviceAccountName: flash-coffee
 
-      {{- if .Values.global.nodeSelectors.enabled }}
+      # ── Feature 5 ── Graceful shutdown budget.
+      # Kubernetes removes the pod from endpoints and sends SIGTERM simultaneously.
+      # The preStop sleep gives the load-balancer time to drain connections before
+      # the process receives SIGTERM. terminationGracePeriodSeconds is the hard
+      # ceiling for the entire shutdown sequence (preStop + SIGTERM handling).
+      terminationGracePeriodSeconds: {{ .Values.coffee.terminationGracePeriodSeconds }}
+
+      # ── Feature 1 ── Topology spread constraints (soft, ScheduleAnyway).
+      # Two constraints: spread across hostnames (nodes) AND across zones.
+      # ScheduleAnyway means a pod is never left Pending due to topology skew.
+      {{- if .Values.coffee.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.coffee.topologySpreadConstraints.maxSkew }}
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: {{ .Values.coffee.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: coffee-server
+        - maxSkew: {{ .Values.coffee.topologySpreadConstraints.maxSkew }}
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: {{ .Values.coffee.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: coffee-server
+      {{- end }}
+
       affinity:
+        {{- if .Values.global.nodeSelectors.enabled }}
+        # Node affinity: hard requirement to land on the correct node pool.
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -27,7 +65,23 @@ spec:
                     operator: In
                     values:
                       - {{ .Values.global.nodeSelectors.other }}
-      {{- end }}
+        {{- end }}
+
+        # ── Feature 2 ── Preferred pod anti-affinity (weight 100).
+        # Adds strong scheduling pressure to avoid co-locating replicas on the
+        # same node WITHOUT ever blocking scheduling (preferred, not required).
+        # Never use requiredDuringScheduling here — it causes Pending pods when
+        # nodes < replicas.
+        {{- if .Values.coffee.podAntiAffinity.enabled }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: {{ .Values.coffee.podAntiAffinity.weight }}
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: coffee-server
+        {{- end }}
 
       {{- if .Values.global.taints.enabled }}
       tolerations:
@@ -96,6 +150,16 @@ spec:
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.coffee.image.repository }}:{{ .Values.coffee.image.tag }}"
           imagePullPolicy: {{ .Values.coffee.image.pullPolicy }}
           command: ["/app/flash-brew/setup_coffee.sh"]
+
+          # ── Feature 5 (continued) ── preStop hook.
+          # Sleeps for preStopSleepSeconds before the container receives SIGTERM,
+          # giving the kube-proxy / cloud LB time to remove this pod from the
+          # active endpoint slice and stop routing new requests to it.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep {{ .Values.coffee.preStopSleepSeconds }}"]
+
           env:
             - name: LOGIQ_UI_GOOGLE_ANALYTICS_CODE
               value: {{ .Values.global.environment.gacode }}
@@ -336,7 +400,13 @@ spec:
 
           ports:
             - containerPort: {{ .Values.coffee.targetPort }}
+              name: http
+              protocol: TCP
 
+          # ── Feature 4 (continued) ── Readiness probe gates rollout traffic.
+          # A pod is only added to the endpoint slice (and receives requests)
+          # once this probe succeeds. During a rolling update the old pod keeps
+          # serving until the new pod passes its readiness check.
           readinessProbe:
             httpGet:
               port: {{ .Values.coffee.targetPort }}
@@ -347,8 +417,20 @@ spec:
             successThreshold: 1
             failureThreshold: 5
 
+          # Liveness probe: restart the container if it becomes unresponsive.
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.coffee.targetPort }}
+              path: /static/js/jquery.min.js
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+
           {{- if .Values.coffee.resources }}
           resources:
             {{- toYaml .Values.coffee.resources | nindent 12 }}
           {{- end }}
+
       restartPolicy: Always

--- a/apica-ascent/charts/flash-coffee/templates/001-coffee-server-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/001-coffee-server-sts.yaml
@@ -417,11 +417,12 @@ spec:
             successThreshold: 1
             failureThreshold: 5
 
-          # Liveness probe: restart the container if it becomes unresponsive.
+          # Liveness probe: restart the container if port 5000 stops responding.
+          # GET / returns HTTP 200 (frontend HTML) — valid 2xx liveness signal.
           livenessProbe:
             httpGet:
               port: {{ .Values.coffee.targetPort }}
-              path: /static/js/jquery.min.js
+              path: /
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 10

--- a/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
@@ -11,279 +11,424 @@ spec:
   selector:
     matchLabels:
       app: coffee-worker
+
+  # ── Feature 4 ── Rolling update: only 1 pod unavailable at a time.
+  # StatefulSet updates proceed pod-by-pod (highest ordinal first).
+  # The readinessProbe below gates traffic so old pods keep serving
+  # until the new pod is fully ready.
+  updateStrategy:
+    type: {{ .Values.coffee_worker.updateStrategy.type }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.coffee_worker.updateStrategy.maxUnavailable }}
+
   template:
     metadata:
       labels:
         app: coffee-worker
     spec:
       serviceAccountName: flash-coffee
-      {{- if .Values.global.nodeSelectors.enabled }}
+
+      # ── Feature 5 ── Graceful shutdown budget.
+      # Kubernetes removes the pod from endpoints and sends SIGTERM simultaneously.
+      # The preStop sleep gives the load-balancer time to drain connections before
+      # the process receives SIGTERM. terminationGracePeriodSeconds is the hard
+      # ceiling for the entire shutdown sequence (preStop + SIGTERM handling).
+      terminationGracePeriodSeconds: {{ .Values.coffee_worker.terminationGracePeriodSeconds }}
+
+      # ── Feature 1 ── Topology spread constraints (soft, ScheduleAnyway).
+      # Two constraints: spread across hostnames (nodes) AND across zones.
+      # ScheduleAnyway means a pod is never left Pending due to topology skew.
+      {{- if .Values.coffee_worker.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.coffee_worker.topologySpreadConstraints.maxSkew }}
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: {{ .Values.coffee_worker.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: coffee-worker
+        - maxSkew: {{ .Values.coffee_worker.topologySpreadConstraints.maxSkew }}
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: {{ .Values.coffee_worker.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: coffee-worker
+      {{- end }}
+
       affinity:
+        {{- if .Values.global.nodeSelectors.enabled }}
+        # Node affinity: hard requirement to land on the correct node pool.
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: {{ .Values.global.nodeSelectors.label }}
-                  operator: In
-                  values:
-                    - {{ .Values.global.nodeSelectors.other }}
-      {{- end }}
+                  - key: {{ .Values.global.nodeSelectors.label }}
+                    operator: In
+                    values:
+                      - {{ .Values.global.nodeSelectors.other }}
+        {{- end }}
+
+        # ── Feature 2 ── Preferred pod anti-affinity (weight 100).
+        # Adds strong scheduling pressure to avoid co-locating replicas on the
+        # same node WITHOUT ever blocking scheduling (preferred, not required).
+        # Never use requiredDuringScheduling here — it causes Pending pods when
+        # nodes < replicas.
+        {{- if .Values.coffee_worker.podAntiAffinity.enabled }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: {{ .Values.coffee_worker.podAntiAffinity.weight }}
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: coffee-worker
+        {{- end }}
+
       {{- if .Values.global.taints.enabled }}
       tolerations:
-      - key: dedicated
-        operator: Equal
-        value: {{ .Values.global.taints.other }}
-        effect: NoSchedule
+        - key: dedicated
+          operator: Equal
+          value: {{ .Values.global.taints.other }}
+          effect: NoSchedule
       {{- end }}
+
       securityContext:
         fsGroup: 1000
         runAsUser: 1000
         runAsGroup: 1000
-      {{ if .Values.useSecret }}
+
+      {{- if .Values.useSecret }}
       imagePullSecrets:
         - name: {{ required "pullSecretName is required" .Values.pullSecretName }}
-      {{ end }}
+      {{- end }}
+
       initContainers:
-      - name: check-redis
-        image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
-        imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - until redis-cli -h {{ .Values.global.environment.redis_host }} ping; do echo "waiting for {{ .Values.global.environment.redis_host }}"; sleep 1;
-          done;
-      - name: check-postgres
-        image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
-        imagePullPolicy: IfNotPresent
-        env:
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: postgres_password
-          - name: POSTGRES_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: postgres_host
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: database_url
-        command: ['sh', '-c',
-          'until pg_isready -h $(POSTGRES_HOST) -p {{ .Values.global.environment.postgres_port}} -d $(DATABASE_URL);
-          do echo waiting for database; sleep 1; done;']
+        - name: check-redis
+          image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+              until redis-cli -h {{ .Values.global.environment.redis_host }} ping;
+              do echo "waiting for {{ .Values.global.environment.redis_host }}"; sleep 1; done;
+
+        - name: check-postgres
+          image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: postgres_password
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: postgres_host
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: database_url
+          command:
+            - sh
+            - -c
+            - >
+              until pg_isready -h $(POSTGRES_HOST) -p {{ .Values.global.environment.postgres_port }}
+              -d $(DATABASE_URL); do echo waiting for database; sleep 1; done;
+
       volumes:
-        {{ if .Values.global.sharedSecretName }}
+        {{- if .Values.global.sharedSecretName }}
         - name: sharedcert
           secret:
             secretName: {{ .Values.global.sharedSecretName }}
-        {{ end }}
+        {{- end }}
+
       containers:
-        - args:
-          - scheduler
-          env:
-          - name: CONFIG_HASH
-            value: {{ include "flash-coffee.confighash" . | quote }}
-          - name: PYTHONUNBUFFERED
-            value: "0"
-          - name: SSR_HOST
-            value: 0.0.0.0
-          - name: COOKIE_SECRET
-            value: d84c0edd-ab5e-4664-b0ee-2cd15a9ae5f0 
-          - name: QUEUES
-            value: queries,scheduled_queries,celery
-          - name: LOG_LEVEL
-            value: ERROR
-          {{ if .Values.global.environment.parent_host }}  
-          - name: PARENT_HOST
-            value: {{ .Values.global.environment.parent_host }}
-          {{ end }}
-          {{ if .Values.global.domain }}  
-          - name: HOST
-            value: {{.Values.global.domain}}
-          {{ end }}
-          - name: MY_APP_NAME
-            value: coffee-worker
-          - name: MY_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: MY_POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP                
-          {{ if .Values.global.environment.cluster_id }}  
-          - name: MY_CLUSTER_ID
-            value: {{ .Values.global.environment.cluster_id }}
-          {{ end }} 
-          - name: LOGIQ_FLASH_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: logiq_flash_host
-          - name: LOGIQ_FLASH_PORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: logiq_flash_port
-          - name: WORKERS_COUNT
-            value: "{{ .Values.coffee_worker.replicaCount }}"
-          - name: REDIS_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: redis_host
-          - name: REDIS_URL
-            value: redis://{{.Values.global.environment.redis_host}}:{{ .Values.global.environment.redis_port}}/0
-          - name: POSTGRES_USER
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: postgres_user
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: postgres_password
-          - name: POSTGRES_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: postgres_host
-          - name: POSTGRES_PORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: postgres_port
-          - name: POSTGRES_DB
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: postgres_db
-          - name: POSTGRES_COFFEE_DB
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: postgres_coffee_db
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: coffee_database_url
-          - name: S3_URL
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: s3_url
-          - name: S3_ACCESS
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_access
-          - name: S3_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_secret
-          - name: S3_BUCKET
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_bucket
-          {{ if .Values.global.environment.admin_name }}
-          - name: ADMIN_NAME
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: admin_name
-          {{ end }}
-          {{ if .Values.global.environment.admin_password }}
-          - name: ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: admin_password
-          {{ end }}
-          {{ if .Values.global.environment.admin_org }}
-          - name: ADMIN_ORG
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: admin_org
-          {{ end }}
-          {{ if .Values.global.environment.admin_email }}
-          - name: ADMIN_EMAIL
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: admin_email
-          {{ end }}
-          {{ if .Values.global.environment.mail_server }}
-          - name: MAIL_SERVER
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: mail_server
-          {{ end }}
-          {{ if .Values.global.environment.mail_port }}
-          - name: MAIL_PORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: mail_port
-          {{ end }}
-          {{ if .Values.global.environment.mail_username }}
-          - name: MAIL_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: mail_username
-          {{ end }}
-          {{ if .Values.global.environment.mail_password }}
-          - name: MAIL_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: mail_password
-          {{ end }}
-          {{ if .Values.global.environment.mail_default_sender }}
-          - name: MAIL_DEFAULT_SENDER
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-coffee.fullname" . }}
-                key: mail_default_sender
-          {{ end }}
-          {{ if .Values.global.chart.prometheus }}
-          - name: PROM_ALERT_MGR_URL
-            value: {{ .Release.Name }}-prometheus-alertmanager:9093
-          {{ end }} 
-          - name: EVENT_REPORTING_WEBHOOKS
-            value: ""
-          - name: LOGIQ_AUDIT_EVENT_GROUP
-            value: logiq-audit
-          volumeMounts:
-          {{ if .Values.global.sharedSecretName }}
-          - mountPath: /app/sharedcerts
-            name: sharedcert
-          {{ end }}
+        - name: coffee-worker
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.coffee_worker.image.repository }}:{{ .Values.coffee_worker.image.tag }}"
-          imagePullPolicy: {{ .Values.coffee_worker.image.pullPolicy}}
-          name: coffee-worker
+          imagePullPolicy: {{ .Values.coffee_worker.image.pullPolicy }}
+          args:
+            - scheduler
+
+          # ── Feature 5 (continued) ── preStop hook.
+          # Sleeps for preStopSleepSeconds before the container receives SIGTERM,
+          # giving the kube-proxy / cloud LB time to drain connections and stop
+          # routing new work items to this worker.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep {{ .Values.coffee_worker.preStopSleepSeconds }}"]
+
+          env:
+            - name: CONFIG_HASH
+              value: {{ include "flash-coffee.confighash" . | quote }}
+
+            - name: PYTHONUNBUFFERED
+              value: "0"
+
+            - name: SSR_HOST
+              value: 0.0.0.0
+
+            - name: COOKIE_SECRET
+              value: d84c0edd-ab5e-4664-b0ee-2cd15a9ae5f0
+
+            - name: QUEUES
+              value: queries,scheduled_queries,celery
+
+            - name: LOG_LEVEL
+              value: ERROR
+
+            {{- if .Values.global.environment.parent_host }}
+            - name: PARENT_HOST
+              value: {{ .Values.global.environment.parent_host }}
+            {{- end }}
+
+            {{- if .Values.global.domain }}
+            - name: HOST
+              value: {{ .Values.global.domain }}
+            {{- end }}
+
+            - name: MY_APP_NAME
+              value: coffee-worker
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+
+            {{- if .Values.global.environment.cluster_id }}
+            - name: MY_CLUSTER_ID
+              value: {{ .Values.global.environment.cluster_id }}
+            {{- end }}
+
+            - name: LOGIQ_FLASH_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: logiq_flash_host
+
+            - name: LOGIQ_FLASH_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: logiq_flash_port
+
+            - name: WORKERS_COUNT
+              value: "{{ .Values.coffee_worker.replicaCount }}"
+
+            - name: REDIS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: redis_host
+
+            - name: REDIS_URL
+              value: redis://{{ .Values.global.environment.redis_host }}:{{ .Values.global.environment.redis_port }}/0
+
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: postgres_user
+
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: postgres_password
+
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: postgres_host
+
+            - name: POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: postgres_port
+
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: postgres_db
+
+            - name: POSTGRES_COFFEE_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: postgres_coffee_db
+
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: coffee_database_url
+
+            - name: S3_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: s3_url
+
+            - name: S3_ACCESS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_access
+
+            - name: S3_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_secret
+
+            - name: S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_bucket
+
+            {{- if .Values.global.environment.admin_name }}
+            - name: ADMIN_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: admin_name
+            {{- end }}
+
+            {{- if .Values.global.environment.admin_password }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: admin_password
+            {{- end }}
+
+            {{- if .Values.global.environment.admin_org }}
+            - name: ADMIN_ORG
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: admin_org
+            {{- end }}
+
+            {{- if .Values.global.environment.admin_email }}
+            - name: ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: admin_email
+            {{- end }}
+
+            {{- if .Values.global.environment.mail_server }}
+            - name: MAIL_SERVER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: mail_server
+            {{- end }}
+
+            {{- if .Values.global.environment.mail_port }}
+            - name: MAIL_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: mail_port
+            {{- end }}
+
+            {{- if .Values.global.environment.mail_username }}
+            - name: MAIL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: mail_username
+            {{- end }}
+
+            {{- if .Values.global.environment.mail_password }}
+            - name: MAIL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: mail_password
+            {{- end }}
+
+            {{- if .Values.global.environment.mail_default_sender }}
+            - name: MAIL_DEFAULT_SENDER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-coffee.fullname" . }}
+                  key: mail_default_sender
+            {{- end }}
+
+            {{- if .Values.global.chart.prometheus }}
+            - name: PROM_ALERT_MGR_URL
+              value: {{ .Release.Name }}-prometheus-alertmanager:9093
+            {{- end }}
+
+            - name: EVENT_REPORTING_WEBHOOKS
+              value: ""
+
+            - name: LOGIQ_AUDIT_EVENT_GROUP
+              value: logiq-audit
+
+          volumeMounts:
+            {{- if .Values.global.sharedSecretName }}
+            - name: sharedcert
+              mountPath: /app/sharedcerts
+            {{- end }}
+
+          # ── Feature 4 (continued) ── Readiness probe gates rollout traffic.
+          # Workers are considered ready once they can accept tasks from the queue.
+          # During a rolling update the old worker keeps processing until the new
+          # one passes its readiness check.
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "redis-cli -h {{ .Values.global.environment.redis_host }} ping | grep -q PONG"
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+
+          # Liveness probe: restart the container if it becomes unresponsive.
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "redis-cli -h {{ .Values.global.environment.redis_host }} ping | grep -q PONG"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+
           {{- if .Values.coffee_worker.resources }}
-          resources: {{- toYaml .Values.coffee_worker.resources | nindent 12 }}
+          resources:
+            {{- toYaml .Values.coffee_worker.resources | nindent 12 }}
           {{- end }}
+
         - name: ssr-report-gen
-          image: {{ .Values.global.imageRegistry}}/logiqai/ssr-server:ssr-v16.0.3
+          image: {{ .Values.global.imageRegistry }}/logiqai/ssr-server:ssr-v16.0.3
           imagePullPolicy: IfNotPresent
           env:
             - name: SSR_HOST
@@ -295,4 +440,5 @@ spec:
               name: ssr
               protocol: TCP
           resources: {}
+
       restartPolicy: Always

--- a/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
@@ -393,32 +393,29 @@ spec:
               mountPath: /app/sharedcerts
             {{- end }}
 
-          # ── Feature 4 (continued) ── Readiness probe gates rollout traffic.
-          # Workers are considered ready once they can accept tasks from the queue.
-          # During a rolling update the old worker keeps processing until the new
-          # one passes its readiness check.
+          # ── Feature 4 (continued) ── Readiness / liveness probes for the worker.
+          #
+          # The ssr-report-gen sidecar in this pod listens on TCP port 5173.
+          # A tcpSocket probe on that port is the cleanest signal: if the SSR
+          # server is accepting connections the pod is healthy and ready.
+          # This avoids any dependency on tools (redis-cli, curl) that may not
+          # be present in the coffee-worker image.
           readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - "redis-cli -h {{ .Values.global.environment.redis_host }} ping | grep -q PONG"
+            tcpSocket:
+              port: 5173
             initialDelaySeconds: 15
             periodSeconds: 15
-            timeoutSeconds: 10
+            timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
 
-          # Liveness probe: restart the container if it becomes unresponsive.
+          # Liveness: restart the container if port 5173 stops accepting connections.
           livenessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - "redis-cli -h {{ .Values.global.environment.redis_host }} ping | grep -q PONG"
+            tcpSocket:
+              port: 5173
             initialDelaySeconds: 30
             periodSeconds: 30
-            timeoutSeconds: 10
+            timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
 

--- a/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
@@ -11,33 +11,21 @@ spec:
   selector:
     matchLabels:
       app: coffee-worker
-
-  # ── Feature 4 ── Rolling update: only 1 pod unavailable at a time.
-  # StatefulSet updates proceed pod-by-pod (highest ordinal first).
-  # The readinessProbe below gates traffic so old pods keep serving
-  # until the new pod is fully ready.
+  # Rolling update: 1 pod down at a time; readinessProbe gates traffic during rollout.
   updateStrategy:
     type: {{ .Values.coffee_worker.updateStrategy.type }}
     rollingUpdate:
       maxUnavailable: {{ .Values.coffee_worker.updateStrategy.maxUnavailable }}
-
   template:
     metadata:
       labels:
         app: coffee-worker
     spec:
       serviceAccountName: flash-coffee
-
-      # ── Feature 5 ── Graceful shutdown budget.
-      # Kubernetes removes the pod from endpoints and sends SIGTERM simultaneously.
-      # The preStop sleep gives the load-balancer time to drain connections before
-      # the process receives SIGTERM. terminationGracePeriodSeconds is the hard
-      # ceiling for the entire shutdown sequence (preStop + SIGTERM handling).
+      # preStop(15s) fills the LB-drain gap before SIGTERM; 60s is the hard ceiling.
       terminationGracePeriodSeconds: {{ .Values.coffee_worker.terminationGracePeriodSeconds }}
 
-      # ── Feature 1 ── Topology spread constraints (soft, ScheduleAnyway).
-      # Two constraints: spread across hostnames (nodes) AND across zones.
-      # ScheduleAnyway means a pod is never left Pending due to topology skew.
+      # Soft spread across nodes and zones — ScheduleAnyway never blocks scheduling.
       {{- if .Values.coffee_worker.topologySpreadConstraints.enabled }}
       topologySpreadConstraints:
         - maxSkew: {{ .Values.coffee_worker.topologySpreadConstraints.maxSkew }}
@@ -56,7 +44,6 @@ spec:
 
       affinity:
         {{- if .Values.global.nodeSelectors.enabled }}
-        # Node affinity: hard requirement to land on the correct node pool.
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -66,12 +53,7 @@ spec:
                     values:
                       - {{ .Values.global.nodeSelectors.other }}
         {{- end }}
-
-        # ── Feature 2 ── Preferred pod anti-affinity (weight 100).
-        # Adds strong scheduling pressure to avoid co-locating replicas on the
-        # same node WITHOUT ever blocking scheduling (preferred, not required).
-        # Never use requiredDuringScheduling here — it causes Pending pods when
-        # nodes < replicas.
+        # Preferred anti-affinity: adds scheduling pressure without ever blocking.
         {{- if .Values.coffee_worker.podAntiAffinity.enabled }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -151,45 +133,32 @@ spec:
           imagePullPolicy: {{ .Values.coffee_worker.image.pullPolicy }}
           args:
             - scheduler
-
-          # ── Feature 5 (continued) ── preStop hook.
-          # Sleeps for preStopSleepSeconds before the container receives SIGTERM,
-          # giving the kube-proxy / cloud LB time to drain connections and stop
-          # routing new work items to this worker.
+          # Sleep before SIGTERM so in-flight tasks can complete before shutdown.
           lifecycle:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep {{ .Values.coffee_worker.preStopSleepSeconds }}"]
-
           env:
             - name: CONFIG_HASH
               value: {{ include "flash-coffee.confighash" . | quote }}
-
             - name: PYTHONUNBUFFERED
               value: "0"
-
             - name: SSR_HOST
               value: 0.0.0.0
-
             - name: COOKIE_SECRET
               value: d84c0edd-ab5e-4664-b0ee-2cd15a9ae5f0
-
             - name: QUEUES
               value: queries,scheduled_queries,celery
-
             - name: LOG_LEVEL
               value: ERROR
-
             {{- if .Values.global.environment.parent_host }}
             - name: PARENT_HOST
               value: {{ .Values.global.environment.parent_host }}
             {{- end }}
-
             {{- if .Values.global.domain }}
             - name: HOST
               value: {{ .Values.global.domain }}
             {{- end }}
-
             - name: MY_APP_NAME
               value: coffee-worker
             - name: MY_NODE_NAME
@@ -208,102 +177,84 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-
             {{- if .Values.global.environment.cluster_id }}
             - name: MY_CLUSTER_ID
               value: {{ .Values.global.environment.cluster_id }}
             {{- end }}
-
             - name: LOGIQ_FLASH_HOST
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: logiq_flash_host
-
             - name: LOGIQ_FLASH_PORT
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: logiq_flash_port
-
             - name: WORKERS_COUNT
               value: "{{ .Values.coffee_worker.replicaCount }}"
-
             - name: REDIS_HOST
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: redis_host
-
             - name: REDIS_URL
               value: redis://{{ .Values.global.environment.redis_host }}:{{ .Values.global.environment.redis_port }}/0
-
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: postgres_user
-
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: postgres_password
-
             - name: POSTGRES_HOST
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: postgres_host
-
             - name: POSTGRES_PORT
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: postgres_port
-
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: postgres_db
-
             - name: POSTGRES_COFFEE_DB
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: postgres_coffee_db
-
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: coffee_database_url
-
             - name: S3_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: s3_url
-
             - name: S3_ACCESS
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.sharedSecretName }}
                   key: s3_access
-
             - name: S3_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.sharedSecretName }}
                   key: s3_secret
-
             - name: S3_BUCKET
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.sharedSecretName }}
                   key: s3_bucket
-
             {{- if .Values.global.environment.admin_name }}
             - name: ADMIN_NAME
               valueFrom:
@@ -311,7 +262,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: admin_name
             {{- end }}
-
             {{- if .Values.global.environment.admin_password }}
             - name: ADMIN_PASSWORD
               valueFrom:
@@ -319,7 +269,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: admin_password
             {{- end }}
-
             {{- if .Values.global.environment.admin_org }}
             - name: ADMIN_ORG
               valueFrom:
@@ -327,7 +276,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: admin_org
             {{- end }}
-
             {{- if .Values.global.environment.admin_email }}
             - name: ADMIN_EMAIL
               valueFrom:
@@ -335,7 +283,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: admin_email
             {{- end }}
-
             {{- if .Values.global.environment.mail_server }}
             - name: MAIL_SERVER
               valueFrom:
@@ -343,7 +290,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: mail_server
             {{- end }}
-
             {{- if .Values.global.environment.mail_port }}
             - name: MAIL_PORT
               valueFrom:
@@ -351,7 +297,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: mail_port
             {{- end }}
-
             {{- if .Values.global.environment.mail_username }}
             - name: MAIL_USERNAME
               valueFrom:
@@ -359,7 +304,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: mail_username
             {{- end }}
-
             {{- if .Values.global.environment.mail_password }}
             - name: MAIL_PASSWORD
               valueFrom:
@@ -367,7 +311,6 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: mail_password
             {{- end }}
-
             {{- if .Values.global.environment.mail_default_sender }}
             - name: MAIL_DEFAULT_SENDER
               valueFrom:
@@ -375,15 +318,12 @@ spec:
                   name: {{ template "flash-coffee.fullname" . }}
                   key: mail_default_sender
             {{- end }}
-
             {{- if .Values.global.chart.prometheus }}
             - name: PROM_ALERT_MGR_URL
               value: {{ .Release.Name }}-prometheus-alertmanager:9093
             {{- end }}
-
             - name: EVENT_REPORTING_WEBHOOKS
               value: ""
-
             - name: LOGIQ_AUDIT_EVENT_GROUP
               value: logiq-audit
 
@@ -393,13 +333,7 @@ spec:
               mountPath: /app/sharedcerts
             {{- end }}
 
-          # ── Feature 4 (continued) ── Readiness / liveness probes for the worker.
-          #
-          # The ssr-report-gen sidecar in this pod listens on TCP port 5173.
-          # A tcpSocket probe on that port is the cleanest signal: if the SSR
-          # server is accepting connections the pod is healthy and ready.
-          # This avoids any dependency on tools (redis-cli, curl) that may not
-          # be present in the coffee-worker image.
+          # tcpSocket on port 5173 (ssr-report-gen sidecar) — no HTTP port on the worker itself.
           readinessProbe:
             tcpSocket:
               port: 5173
@@ -409,7 +343,6 @@ spec:
             successThreshold: 1
             failureThreshold: 3
 
-          # Liveness: restart the container if port 5173 stops accepting connections.
           livenessProbe:
             tcpSocket:
               port: 5173

--- a/apica-ascent/charts/flash-coffee/templates/004-coffee-server-pdb.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/004-coffee-server-pdb.yaml
@@ -1,16 +1,5 @@
-# ── Feature 3 ── PodDisruptionBudget for coffee-server.
-#
-# minAvailable: N-1 guarantees at least N-1 pods remain Running during:
-#   • voluntary disruptions: node drain, cluster upgrades, rollout restarts
-#   • kubectl drain / cordon operations
-#
-# Without a PDB, a node drain can evict ALL pods simultaneously, causing
-# a complete outage. With minAvailable set to replicaCount-1, the cluster
-# will only evict one pod at a time, keeping the service available.
-#
-# Default values.yaml: replicaCount=2 → minAvailable=1
-# For production with replicaCount=3, set coffee.pdb.minAvailable=2
 {{- if .Values.coffee.pdb.enabled }}
+# PodDisruptionBudget: keeps N-1 pods alive during node drains and cluster upgrades.
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -23,8 +12,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 spec:
-  # minAvailable keeps this many pods alive at all times during voluntary disruptions.
-  # Set to replicaCount - 1 so at least one pod always serves traffic.
   minAvailable: {{ .Values.coffee.pdb.minAvailable }}
   selector:
     matchLabels:

--- a/apica-ascent/charts/flash-coffee/templates/004-coffee-server-pdb.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/004-coffee-server-pdb.yaml
@@ -1,0 +1,32 @@
+# ── Feature 3 ── PodDisruptionBudget for coffee-server.
+#
+# minAvailable: N-1 guarantees at least N-1 pods remain Running during:
+#   • voluntary disruptions: node drain, cluster upgrades, rollout restarts
+#   • kubectl drain / cordon operations
+#
+# Without a PDB, a node drain can evict ALL pods simultaneously, causing
+# a complete outage. With minAvailable set to replicaCount-1, the cluster
+# will only evict one pod at a time, keeping the service available.
+#
+# Default values.yaml: replicaCount=2 → minAvailable=1
+# For production with replicaCount=3, set coffee.pdb.minAvailable=2
+{{- if .Values.coffee.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coffee-server-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: coffee-server-deployment
+    app.kubernetes.io/name: coffee-server
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+spec:
+  # minAvailable keeps this many pods alive at all times during voluntary disruptions.
+  # Set to replicaCount - 1 so at least one pod always serves traffic.
+  minAvailable: {{ .Values.coffee.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: coffee-server
+{{- end }}

--- a/apica-ascent/charts/flash-coffee/templates/005-coffee-worker-pdb.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/005-coffee-worker-pdb.yaml
@@ -1,0 +1,31 @@
+# ── Feature 3 ── PodDisruptionBudget for coffee-worker.
+#
+# minAvailable: N-1 guarantees at least N-1 workers remain Running during:
+#   • voluntary disruptions: node drain, cluster upgrades, rollout restarts
+#   • kubectl drain / cordon operations
+#
+# Without a PDB, a node drain can evict ALL workers simultaneously, causing
+# all queued jobs to stall. With minAvailable set to replicaCount-1, the
+# cluster will only evict one worker at a time, keeping job processing alive.
+#
+# Default values.yaml: replicaCount=3 → minAvailable=2
+{{- if .Values.coffee_worker.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coffee-worker-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: coffee-worker-deployment
+    app.kubernetes.io/name: coffee-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+spec:
+  # minAvailable keeps this many workers alive at all times during voluntary disruptions.
+  # Set to replicaCount - 1 so at least two workers always process tasks.
+  minAvailable: {{ .Values.coffee_worker.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: coffee-worker
+{{- end }}

--- a/apica-ascent/charts/flash-coffee/templates/005-coffee-worker-pdb.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/005-coffee-worker-pdb.yaml
@@ -1,15 +1,5 @@
-# ── Feature 3 ── PodDisruptionBudget for coffee-worker.
-#
-# minAvailable: N-1 guarantees at least N-1 workers remain Running during:
-#   • voluntary disruptions: node drain, cluster upgrades, rollout restarts
-#   • kubectl drain / cordon operations
-#
-# Without a PDB, a node drain can evict ALL workers simultaneously, causing
-# all queued jobs to stall. With minAvailable set to replicaCount-1, the
-# cluster will only evict one worker at a time, keeping job processing alive.
-#
-# Default values.yaml: replicaCount=3 → minAvailable=2
 {{- if .Values.coffee_worker.pdb.enabled }}
+# PodDisruptionBudget: keeps N-1 workers alive during node drains and cluster upgrades.
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -22,8 +12,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 spec:
-  # minAvailable keeps this many workers alive at all times during voluntary disruptions.
-  # Set to replicaCount - 1 so at least two workers always process tasks.
   minAvailable: {{ .Values.coffee_worker.pdb.minAvailable }}
   selector:
     matchLabels:

--- a/apica-ascent/charts/flash-coffee/values.yaml
+++ b/apica-ascent/charts/flash-coffee/values.yaml
@@ -82,12 +82,6 @@ ingress:
   #  cpu: 100m
   #  memory: 128Mi
 
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
 global:
   domain: null
   nodePort:

--- a/apica-ascent/charts/flash-coffee/values.yaml
+++ b/apica-ascent/charts/flash-coffee/values.yaml
@@ -15,32 +15,22 @@ coffee:
     pullPolicy: IfNotPresent
   resources: {}
 
-  # High-availability scheduling controls
-  # topologySpreadConstraints: spread pods softly across nodes and zones
   topologySpreadConstraints:
     enabled: true
     maxSkew: 1
-    whenUnsatisfiable: ScheduleAnyway   # never blocks scheduling
-
-  # podAntiAffinity: preferred (soft) — adds scheduling pressure, never blocks
+    whenUnsatisfiable: ScheduleAnyway   # soft — never blocks scheduling
   podAntiAffinity:
     enabled: true
-    weight: 100                          # maximum weight for strongest signal
-
-  # updateStrategy: controls rolling-update behaviour for the StatefulSet
+    weight: 100
   updateStrategy:
     type: RollingUpdate
-    maxUnavailable: 1                    # only 1 pod down at a time during rollout
-
-  # terminationGracePeriodSeconds: total budget for graceful shutdown
-  # preStop sleep fills the gap between endpoint removal and SIGTERM
+    maxUnavailable: 1
   terminationGracePeriodSeconds: 60
   preStopSleepSeconds: 15
-
-  # PodDisruptionBudget: keeps N-1 pods alive during drains / upgrades
+  # N-1 for replicaCount 2; increase minAvailable when scaling up
   pdb:
     enabled: true
-    minAvailable: 1                      # override per-environment; default N-1 for replicaCount 2
+    minAvailable: 1
 
 
 coffee_worker:
@@ -51,24 +41,19 @@ coffee_worker:
   replicaCount: 3
   resources: {}
 
-  # High-availability scheduling controls
   topologySpreadConstraints:
     enabled: true
     maxSkew: 1
-    whenUnsatisfiable: ScheduleAnyway
-
+    whenUnsatisfiable: ScheduleAnyway   # soft — never blocks scheduling
   podAntiAffinity:
     enabled: true
     weight: 100
-
   updateStrategy:
     type: RollingUpdate
     maxUnavailable: 1
-
   terminationGracePeriodSeconds: 60
   preStopSleepSeconds: 15
-
-  # PodDisruptionBudget: for replicaCount 3 → minAvailable 2
+  # N-1 for replicaCount 3
   pdb:
     enabled: true
     minAvailable: 2

--- a/apica-ascent/charts/flash-coffee/values.yaml
+++ b/apica-ascent/charts/flash-coffee/values.yaml
@@ -1,6 +1,5 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 1
 useSecret: false
 pullSecretName:
 
@@ -10,12 +9,39 @@ coffee:
   targetPort: 5000
   replicaCount: 2
   web_workers: 4
-  image: 
+  image:
     repository: logiqai/flash-brew-coffee
     tag: brew.1.2.0
     pullPolicy: IfNotPresent
   resources: {}
-    
+
+  # High-availability scheduling controls
+  # topologySpreadConstraints: spread pods softly across nodes and zones
+  topologySpreadConstraints:
+    enabled: true
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway   # never blocks scheduling
+
+  # podAntiAffinity: preferred (soft) — adds scheduling pressure, never blocks
+  podAntiAffinity:
+    enabled: true
+    weight: 100                          # maximum weight for strongest signal
+
+  # updateStrategy: controls rolling-update behaviour for the StatefulSet
+  updateStrategy:
+    type: RollingUpdate
+    maxUnavailable: 1                    # only 1 pod down at a time during rollout
+
+  # terminationGracePeriodSeconds: total budget for graceful shutdown
+  # preStop sleep fills the gap between endpoint removal and SIGTERM
+  terminationGracePeriodSeconds: 60
+  preStopSleepSeconds: 15
+
+  # PodDisruptionBudget: keeps N-1 pods alive during drains / upgrades
+  pdb:
+    enabled: true
+    minAvailable: 1                      # override per-environment; default N-1 for replicaCount 2
+
 
 coffee_worker:
   image:
@@ -24,6 +50,28 @@ coffee_worker:
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources: {}
+
+  # High-availability scheduling controls
+  topologySpreadConstraints:
+    enabled: true
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway
+
+  podAntiAffinity:
+    enabled: true
+    weight: 100
+
+  updateStrategy:
+    type: RollingUpdate
+    maxUnavailable: 1
+
+  terminationGracePeriodSeconds: 60
+  preStopSleepSeconds: 15
+
+  # PodDisruptionBudget: for replicaCount 3 → minAvailable 2
+  pdb:
+    enabled: true
+    minAvailable: 2
 
 service:
   type: ClusterIP

--- a/apica-ascent/charts/flash-discovery/templates/discoveryPdb.yaml
+++ b/apica-ascent/charts/flash-discovery/templates/discoveryPdb.yaml
@@ -1,0 +1,36 @@
+# ── Feature 3 ── PodDisruptionBudget for flash-discovery.
+#
+# minAvailable: N-1 guarantees at least N-1 pods remain Running during:
+#   • voluntary disruptions: node drain, cluster upgrades, rollout restarts
+#   • kubectl drain / cordon operations
+#
+# Without a PDB, a node drain can evict ALL pods simultaneously, causing
+# a complete service outage. With minAvailable set to replicaCount-1, the
+# cluster will only evict one pod at a time, keeping the service available.
+#
+# Default values.yaml: replicaCountDiscovery=1 → minAvailable=1 (no-op for single replica)
+# Root values.yaml overrides replicaCountDiscovery=2 → minAvailable=1 (N-1)
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "flash-discovery.fullname" . }}-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "flash-discovery.name" . }}
+    chart: {{ template "flash-discovery.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "flash-discovery.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "flash-discovery.chart" . }}
+spec:
+  # minAvailable keeps this many pods alive at all times during voluntary disruptions.
+  # Set to replicaCountDiscovery - 1 so at least one pod always serves traffic.
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ template "flash-discovery.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/apica-ascent/charts/flash-discovery/templates/discoveryPdb.yaml
+++ b/apica-ascent/charts/flash-discovery/templates/discoveryPdb.yaml
@@ -1,16 +1,5 @@
-# ── Feature 3 ── PodDisruptionBudget for flash-discovery.
-#
-# minAvailable: N-1 guarantees at least N-1 pods remain Running during:
-#   • voluntary disruptions: node drain, cluster upgrades, rollout restarts
-#   • kubectl drain / cordon operations
-#
-# Without a PDB, a node drain can evict ALL pods simultaneously, causing
-# a complete service outage. With minAvailable set to replicaCount-1, the
-# cluster will only evict one pod at a time, keeping the service available.
-#
-# Default values.yaml: replicaCountDiscovery=1 → minAvailable=1 (no-op for single replica)
-# Root values.yaml overrides replicaCountDiscovery=2 → minAvailable=1 (N-1)
 {{- if .Values.pdb.enabled }}
+# PodDisruptionBudget: keeps N-1 pods alive during node drains and cluster upgrades.
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -26,8 +15,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ template "flash-discovery.chart" . }}
 spec:
-  # minAvailable keeps this many pods alive at all times during voluntary disruptions.
-  # Set to replicaCountDiscovery - 1 so at least one pod always serves traffic.
   minAvailable: {{ .Values.pdb.minAvailable }}
   selector:
     matchLabels:

--- a/apica-ascent/charts/flash-discovery/templates/discoveryStatefulSet.yaml
+++ b/apica-ascent/charts/flash-discovery/templates/discoveryStatefulSet.yaml
@@ -15,16 +15,11 @@ spec:
     matchLabels:
       app: {{ template "flash-discovery.name" . }}
       release: {{ .Release.Name }}
-
-  # ── Feature 4 ── Rolling update: only 1 pod unavailable at a time.
-  # StatefulSet updates proceed pod-by-pod (highest ordinal first).
-  # The readinessProbe on /ready gates traffic so old pods keep serving
-  # until the new pod is fully ready.
+  # Rolling update: 1 pod down at a time; readinessProbe gates traffic during rollout.
   updateStrategy:
     type: {{ .Values.updateStrategy.type }}
     rollingUpdate:
       maxUnavailable: {{ .Values.updateStrategy.maxUnavailable }}
-
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
@@ -37,7 +32,6 @@ spec:
           requests:
             storage: {{ .Values.persistence.size | quote }}
         storageClassName: {{ .Values.global.persistence.storageClass }}
-
   template:
     metadata:
       labels:
@@ -45,17 +39,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: flash-discovery
-
-      # ── Feature 5 ── Graceful shutdown budget.
-      # Kubernetes removes the pod from endpoints and sends SIGTERM simultaneously.
-      # The preStop sleep gives the load-balancer time to drain connections before
-      # the process receives SIGTERM. terminationGracePeriodSeconds is the hard
-      # ceiling for the entire shutdown sequence (preStop + SIGTERM handling).
+      # preStop(15s) fills the LB-drain gap before SIGTERM; 60s is the hard ceiling.
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 
-      # ── Feature 1 ── Topology spread constraints (soft, ScheduleAnyway).
-      # Two constraints: spread across hostnames (nodes) AND across zones.
-      # ScheduleAnyway means a pod is never left Pending due to topology skew.
+      # Soft spread across nodes and zones — ScheduleAnyway never blocks scheduling.
       {{- if .Values.topologySpreadConstraints.enabled }}
       topologySpreadConstraints:
         - maxSkew: {{ .Values.topologySpreadConstraints.maxSkew }}
@@ -76,8 +63,6 @@ spec:
 
       affinity:
         {{- if .Values.global.nodeSelectors.enabled }}
-        # Node affinity: hard requirement to land on the correct node pool.
-        # Unchanged from original — uses global.nodeSelectors.infra label.
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -87,12 +72,7 @@ spec:
                     values:
                       - {{ .Values.global.nodeSelectors.infra }}
         {{- end }}
-
-        # ── Feature 2 ── Preferred pod anti-affinity (weight 100).
-        # Adds strong scheduling pressure to avoid co-locating replicas on the
-        # same node WITHOUT ever blocking scheduling (preferred, not required).
-        # Never use requiredDuringScheduling here — it causes Pending pods when
-        # nodes < replicas.
+        # Preferred anti-affinity: adds scheduling pressure without ever blocking.
         {{- if .Values.podAntiAffinity.enabled }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -176,16 +156,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-
-          # ── Feature 5 (continued) ── preStop hook.
-          # Sleeps for preStopSleepSeconds before the container receives SIGTERM,
-          # giving the kube-proxy / cloud LB time to remove this pod from the
-          # active endpoint slice and stop routing new requests to it.
+          # Sleep before SIGTERM so the LB stops routing before the process exits.
           lifecycle:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep {{ .Values.preStopSleepSeconds }}"]
-
           env:
             - name: CONFIG_HASH
               value: {{ include "flash-discovery.confighash" . | quote }}
@@ -261,10 +236,7 @@ spec:
               containerPort: {{ .Values.discoveryAPI.port }}
               protocol: TCP
 
-          # ── Feature 4 (continued) ── Readiness probe gates rollout traffic.
-          # A pod is only added to the endpoint slice once /ready returns 200.
-          # During a rolling update the old pod keeps serving until the new pod
-          # passes its readiness check.
+          # Readiness gates endpoint inclusion; old pod keeps serving during rollout.
           readinessProbe:
             httpGet:
               path: /ready
@@ -275,7 +247,6 @@ spec:
             successThreshold: 1
             failureThreshold: 3
 
-          # Liveness probe: restart the container if /live stops returning 200.
           livenessProbe:
             httpGet:
               path: /live

--- a/apica-ascent/charts/flash-discovery/templates/discoveryStatefulSet.yaml
+++ b/apica-ascent/charts/flash-discovery/templates/discoveryStatefulSet.yaml
@@ -15,18 +15,29 @@ spec:
     matchLabels:
       app: {{ template "flash-discovery.name" . }}
       release: {{ .Release.Name }}
+
+  # ── Feature 4 ── Rolling update: only 1 pod unavailable at a time.
+  # StatefulSet updates proceed pod-by-pod (highest ordinal first).
+  # The readinessProbe on /ready gates traffic so old pods keep serving
+  # until the new pod is fully ready.
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.updateStrategy.maxUnavailable }}
+
   volumeClaimTemplates:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: data
-    spec:
-      accessModes:
-        - ReadWriteOnce
-      resources:
-        requests:
-          storage: {{ .Values.persistence.size | quote }}
-      storageClassName: {{ .Values.global.persistence.storageClass }}
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        storageClassName: {{ .Values.global.persistence.storageClass }}
+
   template:
     metadata:
       labels:
@@ -34,145 +45,214 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: flash-discovery
-      {{- if .Values.global.nodeSelectors.enabled }}
+
+      # ── Feature 5 ── Graceful shutdown budget.
+      # Kubernetes removes the pod from endpoints and sends SIGTERM simultaneously.
+      # The preStop sleep gives the load-balancer time to drain connections before
+      # the process receives SIGTERM. terminationGracePeriodSeconds is the hard
+      # ceiling for the entire shutdown sequence (preStop + SIGTERM handling).
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+
+      # ── Feature 1 ── Topology spread constraints (soft, ScheduleAnyway).
+      # Two constraints: spread across hostnames (nodes) AND across zones.
+      # ScheduleAnyway means a pod is never left Pending due to topology skew.
+      {{- if .Values.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.topologySpreadConstraints.maxSkew }}
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ template "flash-discovery.name" . }}
+              release: {{ .Release.Name }}
+        - maxSkew: {{ .Values.topologySpreadConstraints.maxSkew }}
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ template "flash-discovery.name" . }}
+              release: {{ .Release.Name }}
+      {{- end }}
+
       affinity:
+        {{- if .Values.global.nodeSelectors.enabled }}
+        # Node affinity: hard requirement to land on the correct node pool.
+        # Unchanged from original — uses global.nodeSelectors.infra label.
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: {{ .Values.global.nodeSelectors.label }}
-                operator: In
-                values:
-                - {{ .Values.global.nodeSelectors.infra }}
-      {{- end }}
+              - matchExpressions:
+                  - key: {{ .Values.global.nodeSelectors.label }}
+                    operator: In
+                    values:
+                      - {{ .Values.global.nodeSelectors.infra }}
+        {{- end }}
+
+        # ── Feature 2 ── Preferred pod anti-affinity (weight 100).
+        # Adds strong scheduling pressure to avoid co-locating replicas on the
+        # same node WITHOUT ever blocking scheduling (preferred, not required).
+        # Never use requiredDuringScheduling here — it causes Pending pods when
+        # nodes < replicas.
+        {{- if .Values.podAntiAffinity.enabled }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: {{ .Values.podAntiAffinity.weight }}
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: {{ template "flash-discovery.name" . }}
+                    release: {{ .Release.Name }}
+        {{- end }}
+
       {{- if .Values.global.taints.enabled }}
       tolerations:
-      - key: dedicated
-        operator: Equal
-        value: {{ .Values.global.taints.infra }}
-        effect: NoSchedule
+        - key: dedicated
+          operator: Equal
+          value: {{ .Values.global.taints.infra }}
+          effect: NoSchedule
       {{- end }}
+
       securityContext:
         fsGroup: 1000
         runAsUser: 1000
         runAsGroup: 1000
-      initContainers:
-      - name: check-postgres
-        image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
-        imagePullPolicy: IfNotPresent
-        env:
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-discovery.fullname" . }}
-                key: postgres_password
-          - name: POSTGRES_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-discovery.fullname" . }}
-                key: postgres_host
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-discovery.fullname" . }}
-                key: database_url
-        command: ['sh', '-c', 
-          'until pg_isready -h $(POSTGRES_HOST) -p {{ .Values.global.environment.postgres_port}} -d $(DATABASE_URL);
-          do echo waiting for database; sleep 1; done;']
-      {{ if .Values.useSecret }}
+
+      {{- if .Values.useSecret }}
       imagePullSecrets:
         - name: {{ required "pullSecretName is required" .Values.pullSecretName }}
-      {{ end }}
+      {{- end }}
+
+      initContainers:
+        - name: check-postgres
+          image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-discovery.fullname" . }}
+                  key: postgres_password
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-discovery.fullname" . }}
+                  key: postgres_host
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-discovery.fullname" . }}
+                  key: database_url
+          command:
+            - sh
+            - -c
+            - >
+              until pg_isready -h $(POSTGRES_HOST) -p {{ .Values.global.environment.postgres_port }}
+              -d $(DATABASE_URL); do echo waiting for database; sleep 1; done;
+
       volumes:
-        {{ if .Values.configurationFiles }}
+        {{- if .Values.configurationFiles }}
         - name: config
           configMap:
             name: {{ template "flash-discovery.name" . }}-config
-        {{ end }}
-        {{ if .Values.secrets }}
+        {{- end }}
+        {{- if .Values.secrets }}
         - name: certs
           secret:
             secretName: {{ template "flash-discovery.name" . }}-certs
-        {{ end }}
-        {{ if .Values.global.environment.license }}
+        {{- end }}
+        {{- if .Values.global.environment.license }}
         - name: license
           secret:
             secretName: {{ template "flash-discovery.fullname" . }}-license
-        {{ end }}
-        {{ if .Values.global.sharedSecretName }}
+        {{- end }}
+        {{- if .Values.global.sharedSecretName }}
         - name: sharedcert
           secret:
             secretName: {{ .Values.global.sharedSecretName }}
-        {{ end }}
+        {{- end }}
+
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+
+          # ── Feature 5 (continued) ── preStop hook.
+          # Sleeps for preStopSleepSeconds before the container receives SIGTERM,
+          # giving the kube-proxy / cloud LB time to remove this pod from the
+          # active endpoint slice and stop routing new requests to it.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep {{ .Values.preStopSleepSeconds }}"]
+
           env:
-          - name: CONFIG_HASH
-            value: {{ include "flash-discovery.confighash" . | quote }}
-          - name: POSTGRES_USER
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-discovery.fullname" . }}
-                key: postgres_user
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-discovery.fullname" . }}
-                key: postgres_password
-          - name: POSTGRES_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-discovery.fullname" . }}
-                key: postgres_host
-          - name: POSTGRES_PORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-discovery.fullname" . }}
-                key: postgres_port
-          - name: POSTGRES_DB
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "flash-discovery.fullname" . }}
-                key: postgres_db
-          - name: MY_APP_NAME
-            value: {{ template "flash-discovery.name" . }}
-          - name: MY_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: MY_POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP                
-          {{ if .Values.global.environment.cluster_id }}  
-          - name: MY_CLUSTER_ID
-            value: {{ .Values.global.environment.cluster_id }}
-          {{ end }}      
+            - name: CONFIG_HASH
+              value: {{ include "flash-discovery.confighash" . | quote }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-discovery.fullname" . }}
+                  key: postgres_user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-discovery.fullname" . }}
+                  key: postgres_password
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-discovery.fullname" . }}
+                  key: postgres_host
+            - name: POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-discovery.fullname" . }}
+                  key: postgres_port
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flash-discovery.fullname" . }}
+                  key: postgres_db
+            - name: MY_APP_NAME
+              value: {{ template "flash-discovery.name" . }}
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- if .Values.global.environment.cluster_id }}
+            - name: MY_CLUSTER_ID
+              value: {{ .Values.global.environment.cluster_id }}
+            {{- end }}
+
           volumeMounts:
-          - mountPath: /flash/db
-            name: data
-          {{ if .Values.secrets }}
-          - mountPath: /flash/certs
-            name: certs
-          {{ end }}
-          {{ if .Values.global.environment.license }}
-          - mountPath: /flash/license
-            name: license
-          {{ end }}
-          {{ if .Values.global.sharedSecretName }}
-          - mountPath: /flash/sharedcerts
-            name: sharedcert
-          {{ end }}
+            - mountPath: /flash/db
+              name: data
+            {{- if .Values.secrets }}
+            - mountPath: /flash/certs
+              name: certs
+            {{- end }}
+            {{- if .Values.global.environment.license }}
+            - mountPath: /flash/license
+              name: license
+            {{- end }}
+            {{- if .Values.global.sharedSecretName }}
+            - mountPath: /flash/sharedcerts
+              name: sharedcert
+            {{- end }}
+
           ports:
             - name: healthcheck
               containerPort: {{ .Values.discoveryHealth.port }}
@@ -180,31 +260,31 @@ spec:
             - name: discovery
               containerPort: {{ .Values.discoveryAPI.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /live
-              port: healthcheck
-            initialDelaySeconds: 10
-            failureThreshold: 3
-            periodSeconds: 10
+
+          # ── Feature 4 (continued) ── Readiness probe gates rollout traffic.
+          # A pod is only added to the endpoint slice once /ready returns 200.
+          # During a rolling update the old pod keeps serving until the new pod
+          # passes its readiness check.
           readinessProbe:
             httpGet:
               path: /ready
               port: healthcheck
             initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
             failureThreshold: 3
-            periodSeconds: 10             
+
+          # Liveness probe: restart the container if /live stops returning 200.
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: healthcheck
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+
           resources:
-{{ toYaml .Values.resources | indent 12 }}
-    {{ with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{ end }}
-    {{ with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{ end }}
-    {{ with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{ end }}
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/apica-ascent/charts/flash-discovery/values.yaml
+++ b/apica-ascent/charts/flash-discovery/values.yaml
@@ -77,12 +77,6 @@ resources:
   #  cpu: 100m
   #  memory: 128Mi
 
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
 global:
   sharedSecretName: logiq-shared-secret
   nodeSelectors:

--- a/apica-ascent/charts/flash-discovery/values.yaml
+++ b/apica-ascent/charts/flash-discovery/values.yaml
@@ -6,32 +6,19 @@ replicaCountDiscovery: 2
 useSecret: false
 pullSecretName:
 
-# ── High-availability scheduling controls ──────────────────────────────────────
-
-# Feature 1: topologySpreadConstraints — soft spread across nodes and zones.
-# ScheduleAnyway means a pod is never left Pending due to topology skew.
 topologySpreadConstraints:
   enabled: true
   maxSkew: 1
-  whenUnsatisfiable: ScheduleAnyway
-
-# Feature 2: preferred pod anti-affinity — weight 100, never blocks scheduling.
+  whenUnsatisfiable: ScheduleAnyway   # soft — never blocks scheduling
 podAntiAffinity:
   enabled: true
   weight: 100
-
-# Feature 4: rolling update — 1 pod unavailable at a time.
 updateStrategy:
   type: RollingUpdate
   maxUnavailable: 1
-
-# Feature 5: graceful shutdown — preStop(15s) fills LB-drain gap before SIGTERM.
-# terminationGracePeriodSeconds is the hard ceiling for the full shutdown sequence.
 terminationGracePeriodSeconds: 60
 preStopSleepSeconds: 15
-
-# Feature 3: PodDisruptionBudget — keep N-1 pods alive during drains/upgrades.
-# For replicaCountDiscovery=2 (root values.yaml override) → minAvailable=1.
+# N-1 for replicaCountDiscovery=2
 pdb:
   enabled: true
   minAvailable: 1

--- a/apica-ascent/charts/flash-discovery/values.yaml
+++ b/apica-ascent/charts/flash-discovery/values.yaml
@@ -6,6 +6,36 @@ replicaCountDiscovery: 1
 useSecret: false
 pullSecretName:
 
+# ── High-availability scheduling controls ──────────────────────────────────────
+
+# Feature 1: topologySpreadConstraints — soft spread across nodes and zones.
+# ScheduleAnyway means a pod is never left Pending due to topology skew.
+topologySpreadConstraints:
+  enabled: true
+  maxSkew: 1
+  whenUnsatisfiable: ScheduleAnyway
+
+# Feature 2: preferred pod anti-affinity — weight 100, never blocks scheduling.
+podAntiAffinity:
+  enabled: true
+  weight: 100
+
+# Feature 4: rolling update — 1 pod unavailable at a time.
+updateStrategy:
+  type: RollingUpdate
+  maxUnavailable: 1
+
+# Feature 5: graceful shutdown — preStop(15s) fills LB-drain gap before SIGTERM.
+# terminationGracePeriodSeconds is the hard ceiling for the full shutdown sequence.
+terminationGracePeriodSeconds: 60
+preStopSleepSeconds: 15
+
+# Feature 3: PodDisruptionBudget — keep N-1 pods alive during drains/upgrades.
+# For replicaCountDiscovery=2 (root values.yaml override) → minAvailable=1.
+pdb:
+  enabled: true
+  minAvailable: 1
+
 image:
   repository: logiqai/flash-discovery
   tag: 1.0.0

--- a/apica-ascent/charts/flash-discovery/values.yaml
+++ b/apica-ascent/charts/flash-discovery/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCountDiscovery: 1
+replicaCountDiscovery: 2
 useSecret: false
 pullSecretName:
 

--- a/apica-ascent/charts/logiq-flash/templates/pdb-flash.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/pdb-flash.yaml
@@ -1,0 +1,38 @@
+# ── Feature 3 ── PodDisruptionBudget for logiq-flash (primary ingest).
+#
+# minAvailable: N-1 guarantees at least N-1 flash pods remain Running during:
+#   • voluntary disruptions: node drain, cluster upgrades, rollout restarts
+#   • kubectl drain / cordon operations
+#
+# Each flash pod contains 3 containers (flash, logiq-flash-query, logiq-flash-tracing).
+# The PDB protects the pod as a whole — all 3 containers are kept alive together.
+#
+# Without a PDB, a node drain can evict ALL flash pods simultaneously, causing
+# a complete ingest and query outage. With minAvailable set to replicaCount-1,
+# the cluster will only evict one pod at a time, keeping ingest available.
+#
+# Root values.yaml sets replicaCount=2 → minAvailable=1 (N-1).
+{{- if .Values.flash.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "logiq-flash.name" . }}-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "logiq-flash.name" . }}
+    chart: {{ template "logiq-flash.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "logiq-flash.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "logiq-flash.chart" . }}
+spec:
+  # minAvailable keeps this many flash pods alive at all times during voluntary disruptions.
+  # Set to replicaCount - 1 so at least one pod always ingests and serves queries.
+  minAvailable: {{ .Values.flash.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ template "logiq-flash.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/apica-ascent/charts/logiq-flash/templates/pdb-flash.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/pdb-flash.yaml
@@ -1,18 +1,6 @@
-# ── Feature 3 ── PodDisruptionBudget for logiq-flash (primary ingest).
-#
-# minAvailable: N-1 guarantees at least N-1 flash pods remain Running during:
-#   • voluntary disruptions: node drain, cluster upgrades, rollout restarts
-#   • kubectl drain / cordon operations
-#
-# Each flash pod contains 3 containers (flash, logiq-flash-query, logiq-flash-tracing).
-# The PDB protects the pod as a whole — all 3 containers are kept alive together.
-#
-# Without a PDB, a node drain can evict ALL flash pods simultaneously, causing
-# a complete ingest and query outage. With minAvailable set to replicaCount-1,
-# the cluster will only evict one pod at a time, keeping ingest available.
-#
-# Root values.yaml sets replicaCount=2 → minAvailable=1 (N-1).
 {{- if .Values.flash.pdb.enabled }}
+# PodDisruptionBudget: keeps N-1 flash pods alive during node drains and cluster upgrades.
+# Each pod contains 3 containers (flash, logiq-flash-query, logiq-flash-tracing).
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -28,8 +16,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ template "logiq-flash.chart" . }}
 spec:
-  # minAvailable keeps this many flash pods alive at all times during voluntary disruptions.
-  # Set to replicaCount - 1 so at least one pod always ingests and serves queries.
   minAvailable: {{ .Values.flash.pdb.minAvailable }}
   selector:
     matchLabels:

--- a/apica-ascent/charts/logiq-flash/templates/pdb-ml.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/pdb-ml.yaml
@@ -1,15 +1,5 @@
-# ── Feature 3 ── PodDisruptionBudget for logiq-flash-ml.
-#
-# minAvailable: N-1 guarantees at least N-1 ML pods remain Running during:
-#   • voluntary disruptions: node drain, cluster upgrades, rollout restarts
-#   • kubectl drain / cordon operations
-#
-# Without a PDB, a node drain can evict ALL ML pods simultaneously, causing
-# a complete ML processing outage. With minAvailable set to replicaCountMl-1,
-# the cluster will only evict one pod at a time, keeping ML available.
-#
-# Root values.yaml sets replicaCountMl=2 → minAvailable=1 (N-1).
 {{- if .Values.ml.pdb.enabled }}
+# PodDisruptionBudget: keeps N-1 ML pods alive during node drains and cluster upgrades.
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -25,8 +15,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ template "logiq-flash.chart" . }}
 spec:
-  # minAvailable keeps this many ML pods alive at all times during voluntary disruptions.
-  # Set to replicaCountMl - 1 so at least one ML pod always processes requests.
   minAvailable: {{ .Values.ml.pdb.minAvailable }}
   selector:
     matchLabels:

--- a/apica-ascent/charts/logiq-flash/templates/pdb-ml.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/pdb-ml.yaml
@@ -1,0 +1,35 @@
+# ── Feature 3 ── PodDisruptionBudget for logiq-flash-ml.
+#
+# minAvailable: N-1 guarantees at least N-1 ML pods remain Running during:
+#   • voluntary disruptions: node drain, cluster upgrades, rollout restarts
+#   • kubectl drain / cordon operations
+#
+# Without a PDB, a node drain can evict ALL ML pods simultaneously, causing
+# a complete ML processing outage. With minAvailable set to replicaCountMl-1,
+# the cluster will only evict one pod at a time, keeping ML available.
+#
+# Root values.yaml sets replicaCountMl=2 → minAvailable=1 (N-1).
+{{- if .Values.ml.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "logiq-flash.name" . }}-ml-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "logiq-flash.name" . }}-ml
+    chart: {{ template "logiq-flash.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "logiq-flash.name" . }}-ml
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "logiq-flash.chart" . }}
+spec:
+  # minAvailable keeps this many ML pods alive at all times during voluntary disruptions.
+  # Set to replicaCountMl - 1 so at least one ML pod always processes requests.
+  minAvailable: {{ .Values.ml.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ template "logiq-flash.name" . }}-ml
+      release: {{ .Release.Name }}
+{{- end }}

--- a/apica-ascent/charts/logiq-flash/templates/pdb-sync.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/pdb-sync.yaml
@@ -1,15 +1,5 @@
-# ── Feature 3 ── PodDisruptionBudget for logiq-flash-sync.
-#
-# minAvailable: N-1 guarantees at least N-1 sync pods remain Running during:
-#   • voluntary disruptions: node drain, cluster upgrades, rollout restarts
-#   • kubectl drain / cordon operations
-#
-# Without a PDB, a node drain can evict ALL sync pods simultaneously, causing
-# all sync processing to stall. With minAvailable set to replicaCountSync-1,
-# the cluster will only evict one pod at a time, keeping sync available.
-#
-# Root values.yaml sets replicaCountSync=2 → minAvailable=1 (N-1).
 {{- if .Values.sync.pdb.enabled }}
+# PodDisruptionBudget: keeps N-1 sync pods alive during node drains and cluster upgrades.
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -25,8 +15,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ template "logiq-flash.chart" . }}
 spec:
-  # minAvailable keeps this many sync pods alive at all times during voluntary disruptions.
-  # Set to replicaCountSync - 1 so at least one sync pod always processes data.
   minAvailable: {{ .Values.sync.pdb.minAvailable }}
   selector:
     matchLabels:

--- a/apica-ascent/charts/logiq-flash/templates/pdb-sync.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/pdb-sync.yaml
@@ -1,0 +1,35 @@
+# ── Feature 3 ── PodDisruptionBudget for logiq-flash-sync.
+#
+# minAvailable: N-1 guarantees at least N-1 sync pods remain Running during:
+#   • voluntary disruptions: node drain, cluster upgrades, rollout restarts
+#   • kubectl drain / cordon operations
+#
+# Without a PDB, a node drain can evict ALL sync pods simultaneously, causing
+# all sync processing to stall. With minAvailable set to replicaCountSync-1,
+# the cluster will only evict one pod at a time, keeping sync available.
+#
+# Root values.yaml sets replicaCountSync=2 → minAvailable=1 (N-1).
+{{- if .Values.sync.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "logiq-flash.name" . }}-sync-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "logiq-flash.name" . }}-sync
+    chart: {{ template "logiq-flash.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "logiq-flash.name" . }}-sync
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "logiq-flash.chart" . }}
+spec:
+  # minAvailable keeps this many sync pods alive at all times during voluntary disruptions.
+  # Set to replicaCountSync - 1 so at least one sync pod always processes data.
+  minAvailable: {{ .Values.sync.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ template "logiq-flash.name" . }}-sync
+      release: {{ .Release.Name }}
+{{- end }}

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -15,18 +15,30 @@ spec:
     matchLabels:
       app: {{ template "logiq-flash.name" . }}
       release: {{ .Release.Name }}
+
+  # ── Feature 4 ── Rolling update: only 1 pod unavailable at a time.
+  # Each pod contains 3 containers (flash, query, tracing) — all 3 are replaced
+  # together per pod. StatefulSet updates proceed pod-by-pod (highest ordinal first).
+  # The readinessProbe on /ready gates traffic so old pods keep serving until
+  # the new pod passes its readiness check.
+  updateStrategy:
+    type: {{ .Values.flash.updateStrategy.type }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.flash.updateStrategy.maxUnavailable }}
+
   volumeClaimTemplates:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: data
-    spec:
-      accessModes:
-        - ReadWriteOnce
-      resources:
-        requests:
-          storage: {{ .Values.persistence.size | quote }}
-      storageClassName: {{ .Values.global.persistence.storageClass }}
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        storageClassName: {{ .Values.global.persistence.storageClass }}
+
   template:
     metadata:
       annotations:
@@ -36,75 +48,131 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: logiq-flash
-      {{- if .Values.global.nodeSelectors.enabled }}
+
+      # terminationGracePeriodSeconds: 120s — kept at original value.
+      # Flash drains active TCP connections from log shippers (syslog, fluentd,
+      # filebeat, relp). 120s gives enough time for in-flight data to flush.
+      # The preStop hook below fills the LB-drain gap before SIGTERM arrives.
+      terminationGracePeriodSeconds: 120
+
+      # ── Feature 1 ── Topology spread constraint (zone only, ScheduleAnyway).
+      # The hard podAntiAffinity below already guarantees one-pod-per-node,
+      # so the hostname dimension is covered. Only the zone constraint adds
+      # new value: it steers pods across AZs so a zone failure only takes
+      # down a fraction of flash replicas.
+      {{- if .Values.flash.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.flash.topologySpreadConstraints.maxSkew }}
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: {{ .Values.flash.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ template "logiq-flash.name" . }}
+              release: {{ .Release.Name }}
+      {{- end }}
+
       affinity:
+        {{- if .Values.global.nodeSelectors.enabled }}
+        # Node affinity: hard requirement to land on the ingest node pool.
+        # Unchanged from original — uses global.nodeSelectors.ingest label.
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: {{ .Values.global.nodeSelectors.label }}
-                  operator: In
-                  values:
-                    - {{ .Values.global.nodeSelectors.ingest }}
-      {{- end }}
+                  - key: {{ .Values.global.nodeSelectors.label }}
+                    operator: In
+                    values:
+                      - {{ .Values.global.nodeSelectors.ingest }}
+        {{- end }}
+
+        podAntiAffinity:
+          {{- if .Values.podPerNode }}
+          # Hard pod anti-affinity (podPerNode) — UNCHANGED.
+          # Guarantees one logiq-flash pod per node. Will cause Pending if
+          # nodes < replicas. This is the existing design intent.
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - {{ template "logiq-flash.name" . }}
+              topologyKey: kubernetes.io/hostname
+          {{- end }}
+
+          # NOTE: preferred podAntiAffinity on kubernetes.io/hostname is intentionally
+          # omitted here. The required rule above already eliminates all nodes that
+          # have a logiq-flash pod, so a preferred rule on the same topologyKey
+          # would operate on a set of nodes with zero logiq-flash pods — adding
+          # zero scheduling influence. The zone-level signal is handled by
+          # topologySpreadConstraints above.
+
       {{- if .Values.global.taints.enabled }}
       tolerations:
-      - key: dedicated
-        operator: Equal
-        value: {{ .Values.global.taints.ingest }}
-        effect: NoSchedule
+        - key: dedicated
+          operator: Equal
+          value: {{ .Values.global.taints.ingest }}
+          effect: NoSchedule
       {{- end }}
+
       securityContext:
         fsGroup: 1000
         runAsUser: 1000
         runAsGroup: 1000
+
       initContainers:
-      - command:
-        - sh
-        - -c
-        - until $(curl --output /dev/null --silent --fail http://flash-discovery:8081/ready); do echo "waiting for discovery"; sleep 1;
-          done;
-        image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
-        imagePullPolicy: IfNotPresent
-        name: check-discovery
-      - name: check-redis
-        image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
-        imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - until redis-cli -h {{ .Values.global.environment.redis_host }} ping; do echo "waiting for {{ .Values.global.environment.redis_host }}"; sleep 1;
-          done;
-{{ if .Values.global.chart.s3gateway }}                
-      - command:
-          - sh
-          - -c
-          - until $(curl --output /dev/null --silent --fail http://s3-gateway:9000/minio/health/ready); do echo "waiting for s3-gateway"; sleep 1;
-            done;
-        image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
-        imagePullPolicy: IfNotPresent
-        name: check-s3-gateway
-{{ end }}            
+        - name: check-discovery
+          image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+              until $(curl --output /dev/null --silent --fail http://flash-discovery:8081/ready);
+              do echo "waiting for discovery"; sleep 1; done;
+
+        - name: check-redis
+          image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+              until redis-cli -h {{ .Values.global.environment.redis_host }} ping;
+              do echo "waiting for {{ .Values.global.environment.redis_host }}"; sleep 1; done;
+
+        {{- if .Values.global.chart.s3gateway }}
+        - name: check-s3-gateway
+          image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+              until $(curl --output /dev/null --silent --fail http://s3-gateway:9000/minio/health/ready);
+              do echo "waiting for s3-gateway"; sleep 1; done;
+        {{- end }}
+
       volumes:
-        {{ if .Values.configurationFiles }}
+        {{- if .Values.configurationFiles }}
         - name: config
           configMap:
-            {{ if not .Values.configMapName }}
+            {{- if not .Values.configMapName }}
             name: logiq-config
-            {{ else }}
+            {{- else }}
             name: {{ .Values.configMapName }}
-            {{ end }}
-        {{ end }}
-        {{ if .Values.secrets_name }}
+            {{- end }}
+        {{- end }}
+        {{- if .Values.secrets_name }}
         - name: certs
           secret:
             secretName: {{ .Values.secrets_name }}
-        {{ end }}
-        {{ if .Values.global.sharedSecretName }}
+        {{- end }}
+        {{- if .Values.global.sharedSecretName }}
         - name: sharedcert
           secret:
             secretName: {{ .Values.global.sharedSecretName }}
-        {{ end }}
+        {{- end }}
         {{- if .Values.kafka_client.enabled }}
         - name: apica-kafka-secret
           secret:
@@ -123,153 +191,155 @@ spec:
           configMap:
             name: {{ .Values.global.environment.s3_custom_ca.map_name }}
         {{- end }}
-      {{ if .Values.podPerNode }}
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - {{ template "logiq-flash.name" . }}
-            topologyKey: "kubernetes.io/hostname"
-      {{ end }}
-      terminationGracePeriodSeconds: 120
+
       containers:
+        # ── Primary ingest container ──────────────────────────────────────────
         - name: {{ .Chart.Name }}
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-          - -c
-          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id flash1 -pg_max_idle_conns 3 -pg_max_open_Conns 5 -postgres_timeout 20s -workers 150 -connection_channel_size 10 --pg_conn_max_lifetime 5m {{ .Values.global.environment.extraflag }} {{- if .Values.logflow_only.enabled }} {{ .Values.logflow_only.args }} {{- end }} {{- if .Values.kafka_client.enabled }} {{ .Values.kafka_client.kafka_args }} {{- end }}
           command:
-          - /bin/bash
+            - /bin/bash
+          args:
+            - -c
+            - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id flash1 -pg_max_idle_conns 3 -pg_max_open_Conns 5 -postgres_timeout 20s -workers 150 -connection_channel_size 10 --pg_conn_max_lifetime 5m {{ .Values.global.environment.extraflag }} {{- if .Values.logflow_only.enabled }} {{ .Values.logflow_only.args }} {{- end }} {{- if .Values.kafka_client.enabled }} {{ .Values.kafka_client.kafka_args }} {{- end }}
+
+          # ── Feature 5 ── preStop hook.
+          # Sleeps 30s before SIGTERM — gives kube-proxy and cloud LB time to
+          # stop routing new log shipper connections to this pod. 30s is used
+          # (vs 15s elsewhere) because flash handles more persistent TCP connections
+          # (syslog, fluentd, filebeat, relp). Total budget: 30s + 90s = 120s ceiling.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep {{ .Values.flash.preStopSleepSeconds }}"]
+
           env:
-          - name: CONFIG_HASH
-            value: {{ include "logiq-flash.confighash" . | quote }}
-          - name: DISCOVERY_URL
-            value: http://{{ .Values.discoveryService.name }}:4000
-          - name: DISCOVERY_ID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: DISCOVERY_DOMAIN
-            value: {{ template "logiq-flash.name" . }}-headless
-          {{ if .Values.global.environment.parent_host }}  
-          - name: PARENT_HOST
-            value: {{ .Values.global.environment.parent_host }}
-          {{ end }}
-          {{ if .Values.global.environment.redis_opts }}
-          - name: REDIS_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: redis_host
-          - name: REDIS_PORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: redis_port
-          {{ end }}
-          {{ if .Values.global.environment.admin_email }}
-          - name: ADMIN_EMAIL
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: admin_email
-          {{ end }}
-          {{ if .Values.global.environment.admin_password }}
-          - name: ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: admin_password
-          {{ end }}
-          - name: POSTGRES_USER
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_user
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_password
-          - name: POSTGRES_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_host
-          - name: POSTGRES_PORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_port
-          - name: POSTGRES_DB
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_db
-          - name: S3_ACCESS
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_access
-          - name: S3_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_secret
-          - name: S3_BUCKET
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_bucket
-          {{ if .Values.global.environment.cluster_id }}  
-          - name: MY_CLUSTER_ID
-            value: {{ .Values.global.environment.cluster_id }}
-          {{ end }}
-          - name: MY_APP_NAME
-            value: {{ template "logiq-flash.name" . }}
-          - name: MY_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: MY_POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
+            - name: CONFIG_HASH
+              value: {{ include "logiq-flash.confighash" . | quote }}
+            - name: DISCOVERY_URL
+              value: http://{{ .Values.discoveryService.name }}:4000
+            - name: DISCOVERY_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: DISCOVERY_DOMAIN
+              value: {{ template "logiq-flash.name" . }}-headless
+            {{- if .Values.global.environment.parent_host }}
+            - name: PARENT_HOST
+              value: {{ .Values.global.environment.parent_host }}
+            {{- end }}
+            {{- if .Values.global.environment.redis_opts }}
+            - name: REDIS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: redis_host
+            - name: REDIS_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: redis_port
+            {{- end }}
+            {{- if .Values.global.environment.admin_email }}
+            - name: ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: admin_email
+            {{- end }}
+            {{- if .Values.global.environment.admin_password }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: admin_password
+            {{- end }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_password
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_host
+            - name: POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_port
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_db
+            - name: S3_ACCESS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_access
+            - name: S3_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_secret
+            - name: S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_bucket
+            {{- if .Values.global.environment.cluster_id }}
+            - name: MY_CLUSTER_ID
+              value: {{ .Values.global.environment.cluster_id }}
+            {{- end }}
+            - name: MY_APP_NAME
+              value: {{ template "logiq-flash.name" . }}
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+
           volumeMounts:
-          - mountPath: /flash/config
-            name: config
-          {{- if .Values.kafka_client.enabled }}
-          - mountPath: /flash/kafka
-            name: apica-kafka-secret
-          {{- end }}
-          - mountPath: /flash/db
-            name: data
-          {{ if .Values.secrets_name }}
-          - mountPath: /flash/certs
-            name: certs
-          {{ end }}
-          {{ if .Values.global.sharedSecretName }}
-          - mountPath: /flash/sharedcerts
-            name: sharedcert
-          {{ end }}
-          {{- if .Values.global.environment.s3_custom_ca.enabled }}
-          - mountPath: /etc/ssl/certs/ca.crt
-            name: s3-custom-ca
-            subPath: ca.crt
-          {{- end }}
+            - mountPath: /flash/config
+              name: config
+            {{- if .Values.kafka_client.enabled }}
+            - mountPath: /flash/kafka
+              name: apica-kafka-secret
+            {{- end }}
+            - mountPath: /flash/db
+              name: data
+            {{- if .Values.secrets_name }}
+            - mountPath: /flash/certs
+              name: certs
+            {{- end }}
+            {{- if .Values.global.sharedSecretName }}
+            - mountPath: /flash/sharedcerts
+              name: sharedcert
+            {{- end }}
+            {{- if .Values.global.environment.s3_custom_ca.enabled }}
+            - mountPath: /etc/ssl/certs/ca.crt
+              name: s3-custom-ca
+              subPath: ca.crt
+            {{- end }}
+
           ports:
             - name: grpc
               containerPort: 50054
@@ -319,208 +389,255 @@ spec:
             - name: rawtcp
               containerPort: 517
               protocol: TCP
+
+          # ── Feature 4 (continued) ── Readiness probe gates rollout traffic.
+          # failureThreshold: 25 is intentional — flash needs time for Raft
+          # consensus, WAL replay, and write buffer warm-up before serving.
           readinessProbe:
             httpGet:
               path: /ready
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 125
             successThreshold: 1
             failureThreshold: 25
+
+          # Liveness probe: restart if /ready stops responding.
+          # failureThreshold: 25 matches readiness — same Raft/WAL reasoning.
+          # A lower threshold would cause restart loops during legitimate recovery.
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
             timeoutSeconds: 125
+            successThreshold: 1
+            failureThreshold: 25
+
           resources:
-{{ toYaml .Values.resources.ingest | indent 12 }}
+            {{- toYaml .Values.resources.ingest | nindent 12 }}
+
+        # ── Query sidecar container ───────────────────────────────────────────
+        # Same binary as primary, --sidecar-node flag, separate ports.
         - name: logiq-flash-query
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-          - -c
-          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id $(DISCOVERY_ID) -pg_max_idle_conns 3 -pg_max_open_Conns 10 -postgres_timeout 20s --pg_conn_max_lifetime 5m -grpc_port 51054 -health_check_port 18080 --sidecar-node -api_port 19999 {{ .Values.global.environment.extraflag }}
           command:
-          - /bin/bash
+            - /bin/bash
+          args:
+            - -c
+            - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id $(DISCOVERY_ID) -pg_max_idle_conns 3 -pg_max_open_Conns 10 -postgres_timeout 20s --pg_conn_max_lifetime 5m -grpc_port 51054 -health_check_port 18080 --sidecar-node -api_port 19999 {{ .Values.global.environment.extraflag }}
+
           env:
-          - name: CONFIG_HASH
-            value: {{ include "logiq-flash.confighash" . | quote }}
-          - name: DISCOVERY_URL
-            value: http://{{ .Values.discoveryService.name }}:4000
-          - name: DISCOVERY_ID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: DISCOVERY_DOMAIN
-            value: {{ template "logiq-flash.name" . }}-headless
-          {{ if .Values.global.environment.redis_opts }}
-          - name: REDIS_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: redis_host
-          - name: REDIS_PORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: redis_port
-          {{ end }}
-          {{ if .Values.global.environment.admin_email }}
-          - name: ADMIN_EMAIL
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: admin_email
-          {{ end }}
-          {{ if .Values.global.environment.admin_password }}
-          - name: ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: admin_password
-          {{ end }}
-          - name: POSTGRES_USER
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_user
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_password
-          - name: POSTGRES_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_host
-          - name: POSTGRES_PORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_port
-          - name: POSTGRES_DB
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_db
-          - name: S3_ACCESS
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_access
-          - name: S3_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_secret
-          - name: S3_BUCKET
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_bucket
-          {{ if .Values.global.environment.cluster_id }}  
-          - name: MY_CLUSTER_ID
-            value: {{ .Values.global.environment.cluster_id }}
-          {{ end }}
-          - name: MY_APP_NAME
-            value: {{ template "logiq-flash.name" . }}
-          - name: MY_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: MY_POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
+            - name: CONFIG_HASH
+              value: {{ include "logiq-flash.confighash" . | quote }}
+            - name: DISCOVERY_URL
+              value: http://{{ .Values.discoveryService.name }}:4000
+            - name: DISCOVERY_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: DISCOVERY_DOMAIN
+              value: {{ template "logiq-flash.name" . }}-headless
+            {{- if .Values.global.environment.redis_opts }}
+            - name: REDIS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: redis_host
+            - name: REDIS_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: redis_port
+            {{- end }}
+            {{- if .Values.global.environment.admin_email }}
+            - name: ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: admin_email
+            {{- end }}
+            {{- if .Values.global.environment.admin_password }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: admin_password
+            {{- end }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_password
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_host
+            - name: POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_port
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_db
+            - name: S3_ACCESS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_access
+            - name: S3_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_secret
+            - name: S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_bucket
+            {{- if .Values.global.environment.cluster_id }}
+            - name: MY_CLUSTER_ID
+              value: {{ .Values.global.environment.cluster_id }}
+            {{- end }}
+            - name: MY_APP_NAME
+              value: {{ template "logiq-flash.name" . }}
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+
           ports:
-          - containerPort: 51054
-            name: grpc
-            protocol: TCP
-          - containerPort: 8899
-            name: webcli
-            protocol: TCP
-          - containerPort: 19999
-            name: api
-            protocol: TCP
-          - containerPort: 18080
-            name: healthcheck
-            protocol: TCP
+            - containerPort: 51054
+              name: grpc
+              protocol: TCP
+            - containerPort: 8899
+              name: webcli
+              protocol: TCP
+            - containerPort: 19999
+              name: api
+              protocol: TCP
+            - containerPort: 18080
+              name: healthcheck
+              protocol: TCP
+
+          # Readiness probe — failureThreshold: 25 intentional (same as primary).
           readinessProbe:
-            failureThreshold: 25
             httpGet:
               path: /ready
               port: 18080
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
-            successThreshold: 1
             timeoutSeconds: 125
+            successThreshold: 1
+            failureThreshold: 25
+
+          # Liveness probe — failureThreshold: 25 intentional.
+          # Query sidecar runs same binary; same Raft/WAL recovery characteristics.
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 18080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 125
+            successThreshold: 1
+            failureThreshold: 25
+
           volumeMounts:
-          - mountPath: /flash/config
-            name: config
-          - mountPath: /flash/db
-            name: data
-          {{ if .Values.secrets_name }}
-          - mountPath: /flash/certs
-            name: certs
-          {{ end }}
-          {{ if .Values.global.sharedSecretName }}
-          - mountPath: /flash/sharedcerts
-            name: sharedcert
-          {{ end }}
-          {{- if .Values.global.environment.s3_custom_ca.enabled }}
-          - mountPath: /etc/ssl/certs/ca.crt
-            name: s3-custom-ca
-            subPath: ca.crt
-          {{- end }}
+            - mountPath: /flash/config
+              name: config
+            - mountPath: /flash/db
+              name: data
+            {{- if .Values.secrets_name }}
+            - mountPath: /flash/certs
+              name: certs
+            {{- end }}
+            {{- if .Values.global.sharedSecretName }}
+            - mountPath: /flash/sharedcerts
+              name: sharedcert
+            {{- end }}
+            {{- if .Values.global.environment.s3_custom_ca.enabled }}
+            - mountPath: /etc/ssl/certs/ca.crt
+              name: s3-custom-ca
+              subPath: ca.crt
+            {{- end }}
+
           resources:
-{{ toYaml .Values.resources.sidecarQuery | indent 12 }}
+            {{- toYaml .Values.resources.sidecarQuery | nindent 12 }}
+
+        # ── Tracing collector sidecar ─────────────────────────────────────────
+        # Jaeger collector — receives traces via gRPC, stores via localhost:50054.
         - name: {{ .Chart.Name }}-tracing
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.sidecarTracing.image }}:{{ .Values.sidecarTracing.tag }}"
           imagePullPolicy: {{ .Values.sidecarTracing.pullPolicy }}
           command:
-          - /bin/sh
-          - -c
-          - |
-            while true 
-            do
-            /go/bin/collector-linux --grpc-storage.server=localhost:50054
-            sleep 5
-            done
+            - /bin/sh
+            - -c
+            - |
+              while true
+              do
+              /go/bin/collector-linux --grpc-storage.server=localhost:50054
+              sleep 5
+              done
           env:
-          - name: SPAN_STORAGE_TYPE
-            value: grpc-plugin
+            - name: SPAN_STORAGE_TYPE
+              value: grpc-plugin
+
+          ports:
+            - containerPort: 14250
+              name: tracing-2
+              protocol: TCP
+            - containerPort: 14268
+              name: tracing-1
+              protocol: TCP
+
+          # Readiness probe — tcpSocket on 14250 (Jaeger gRPC collector port).
           readinessProbe:
             tcpSocket:
               port: 14250
             initialDelaySeconds: 25
             periodSeconds: 25
+            timeoutSeconds: 125
             successThreshold: 1
             failureThreshold: 3
+
+          # Liveness probe — same as readiness.
+          # failureThreshold: 3 is correct here — tracing sidecar has no Raft/WAL,
+          # it just restarts the collector loop. Fast restart is safe.
+          livenessProbe:
+            tcpSocket:
+              port: 14250
+            initialDelaySeconds: 30
+            periodSeconds: 25
             timeoutSeconds: 125
+            successThreshold: 1
+            failureThreshold: 3
+
           resources:
-{{ toYaml .Values.resources.sidecarTracing | indent 12 }}
-          ports:
-          - containerPort: 14250
-            name: tracing-2
-            protocol: TCP
-          - containerPort: 14268
-            name: tracing-1
-            protocol: TCP
-    {{ with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{ end }}
-    {{ with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{ end }}
-    {{ with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{ end }}
+            {{- toYaml .Values.resources.sidecarTracing | nindent 12 }}

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -15,17 +15,11 @@ spec:
     matchLabels:
       app: {{ template "logiq-flash.name" . }}
       release: {{ .Release.Name }}
-
-  # ── Feature 4 ── Rolling update: only 1 pod unavailable at a time.
-  # Each pod contains 3 containers (flash, query, tracing) — all 3 are replaced
-  # together per pod. StatefulSet updates proceed pod-by-pod (highest ordinal first).
-  # The readinessProbe on /ready gates traffic so old pods keep serving until
-  # the new pod passes its readiness check.
+  # Rolling update: 1 pod (3 containers) down at a time; readinessProbe gates traffic.
   updateStrategy:
     type: {{ .Values.flash.updateStrategy.type }}
     rollingUpdate:
       maxUnavailable: {{ .Values.flash.updateStrategy.maxUnavailable }}
-
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
@@ -38,7 +32,6 @@ spec:
           requests:
             storage: {{ .Values.persistence.size | quote }}
         storageClassName: {{ .Values.global.persistence.storageClass }}
-
   template:
     metadata:
       annotations:
@@ -48,18 +41,11 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: logiq-flash
-
-      # terminationGracePeriodSeconds: 120s — kept at original value.
-      # Flash drains active TCP connections from log shippers (syslog, fluentd,
-      # filebeat, relp). 120s gives enough time for in-flight data to flush.
-      # The preStop hook below fills the LB-drain gap before SIGTERM arrives.
+      # 120s kept intentionally — flash drains active TCP connections from log shippers.
+      # preStop(30s) fills the LB-drain gap; budget: 30s preStop + 90s SIGTERM = 120s.
       terminationGracePeriodSeconds: 120
 
-      # ── Feature 1 ── Topology spread constraint (zone only, ScheduleAnyway).
-      # The hard podAntiAffinity below already guarantees one-pod-per-node,
-      # so the hostname dimension is covered. Only the zone constraint adds
-      # new value: it steers pods across AZs so a zone failure only takes
-      # down a fraction of flash replicas.
+      # Zone-only spread — hard podAntiAffinity already covers the hostname dimension.
       {{- if .Values.flash.topologySpreadConstraints.enabled }}
       topologySpreadConstraints:
         - maxSkew: {{ .Values.flash.topologySpreadConstraints.maxSkew }}
@@ -73,8 +59,6 @@ spec:
 
       affinity:
         {{- if .Values.global.nodeSelectors.enabled }}
-        # Node affinity: hard requirement to land on the ingest node pool.
-        # Unchanged from original — uses global.nodeSelectors.ingest label.
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -87,9 +71,7 @@ spec:
 
         podAntiAffinity:
           {{- if .Values.podPerNode }}
-          # Hard pod anti-affinity (podPerNode) — UNCHANGED.
-          # Guarantees one logiq-flash pod per node. Will cause Pending if
-          # nodes < replicas. This is the existing design intent.
+          # Hard rule: one logiq-flash pod per node. Pods go Pending if nodes < replicas.
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchExpressions:
@@ -99,13 +81,7 @@ spec:
                       - {{ template "logiq-flash.name" . }}
               topologyKey: kubernetes.io/hostname
           {{- end }}
-
-          # NOTE: preferred podAntiAffinity on kubernetes.io/hostname is intentionally
-          # omitted here. The required rule above already eliminates all nodes that
-          # have a logiq-flash pod, so a preferred rule on the same topologyKey
-          # would operate on a set of nodes with zero logiq-flash pods — adding
-          # zero scheduling influence. The zone-level signal is handled by
-          # topologySpreadConstraints above.
+          # Preferred anti-affinity omitted on hostname — shadowed by the hard rule above.
 
       {{- if .Values.global.taints.enabled }}
       tolerations:
@@ -193,7 +169,7 @@ spec:
         {{- end }}
 
       containers:
-        # ── Primary ingest container ──────────────────────────────────────────
+        # Primary ingest container — receives logs via syslog/CEF/relp/fluentd/filebeat/gRPC.
         - name: {{ .Chart.Name }}
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -202,17 +178,11 @@ spec:
           args:
             - -c
             - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id flash1 -pg_max_idle_conns 3 -pg_max_open_Conns 5 -postgres_timeout 20s -workers 150 -connection_channel_size 10 --pg_conn_max_lifetime 5m {{ .Values.global.environment.extraflag }} {{- if .Values.logflow_only.enabled }} {{ .Values.logflow_only.args }} {{- end }} {{- if .Values.kafka_client.enabled }} {{ .Values.kafka_client.kafka_args }} {{- end }}
-
-          # ── Feature 5 ── preStop hook.
-          # Sleeps 30s before SIGTERM — gives kube-proxy and cloud LB time to
-          # stop routing new log shipper connections to this pod. 30s is used
-          # (vs 15s elsewhere) because flash handles more persistent TCP connections
-          # (syslog, fluentd, filebeat, relp). Total budget: 30s + 90s = 120s ceiling.
+          # 30s sleep before SIGTERM — more persistent connections than other workloads.
           lifecycle:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep {{ .Values.flash.preStopSleepSeconds }}"]
-
           env:
             - name: CONFIG_HASH
               value: {{ include "logiq-flash.confighash" . | quote }}
@@ -390,9 +360,8 @@ spec:
               containerPort: 517
               protocol: TCP
 
-          # ── Feature 4 (continued) ── Readiness probe gates rollout traffic.
-          # failureThreshold: 25 is intentional — flash needs time for Raft
-          # consensus, WAL replay, and write buffer warm-up before serving.
+          # failureThreshold: 25 intentional — Raft re-election and WAL replay can take minutes.
+          # A lower threshold causes restart loops during legitimate recovery.
           readinessProbe:
             httpGet:
               path: /ready
@@ -403,9 +372,6 @@ spec:
             successThreshold: 1
             failureThreshold: 25
 
-          # Liveness probe: restart if /ready stops responding.
-          # failureThreshold: 25 matches readiness — same Raft/WAL reasoning.
-          # A lower threshold would cause restart loops during legitimate recovery.
           livenessProbe:
             httpGet:
               path: /ready
@@ -419,8 +385,7 @@ spec:
           resources:
             {{- toYaml .Values.resources.ingest | nindent 12 }}
 
-        # ── Query sidecar container ───────────────────────────────────────────
-        # Same binary as primary, --sidecar-node flag, separate ports.
+        # Query sidecar — same binary as primary, --sidecar-node flag, separate ports.
         - name: logiq-flash-query
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -429,7 +394,6 @@ spec:
           args:
             - -c
             - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -discovery_domain $(DISCOVERY_DOMAIN) -discovery_url $(DISCOVERY_URL) -discovery_id $(DISCOVERY_ID) -pg_max_idle_conns 3 -pg_max_open_Conns 10 -postgres_timeout 20s --pg_conn_max_lifetime 5m -grpc_port 51054 -health_check_port 18080 --sidecar-node -api_port 19999 {{ .Values.global.environment.extraflag }}
-
           env:
             - name: CONFIG_HASH
               value: {{ include "logiq-flash.confighash" . | quote }}
@@ -544,7 +508,7 @@ spec:
               name: healthcheck
               protocol: TCP
 
-          # Readiness probe — failureThreshold: 25 intentional (same as primary).
+          # failureThreshold: 25 intentional — same Raft/WAL recovery as primary container.
           readinessProbe:
             httpGet:
               path: /ready
@@ -556,8 +520,6 @@ spec:
             successThreshold: 1
             failureThreshold: 25
 
-          # Liveness probe — failureThreshold: 25 intentional.
-          # Query sidecar runs same binary; same Raft/WAL recovery characteristics.
           livenessProbe:
             httpGet:
               path: /ready
@@ -591,8 +553,7 @@ spec:
           resources:
             {{- toYaml .Values.resources.sidecarQuery | nindent 12 }}
 
-        # ── Tracing collector sidecar ─────────────────────────────────────────
-        # Jaeger collector — receives traces via gRPC, stores via localhost:50054.
+        # Jaeger collector sidecar — receives traces via gRPC, stores via localhost:50054.
         - name: {{ .Chart.Name }}-tracing
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.sidecarTracing.image }}:{{ .Values.sidecarTracing.tag }}"
           imagePullPolicy: {{ .Values.sidecarTracing.pullPolicy }}
@@ -617,7 +578,6 @@ spec:
               name: tracing-1
               protocol: TCP
 
-          # Readiness probe — tcpSocket on 14250 (Jaeger gRPC collector port).
           readinessProbe:
             tcpSocket:
               port: 14250
@@ -627,9 +587,7 @@ spec:
             successThreshold: 1
             failureThreshold: 3
 
-          # Liveness probe — same as readiness.
-          # failureThreshold: 3 is correct here — tracing sidecar has no Raft/WAL,
-          # it just restarts the collector loop. Fast restart is safe.
+          # failureThreshold: 3 — tracing sidecar has no state; fast restart is safe.
           livenessProbe:
             tcpSocket:
               port: 14250

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -249,6 +249,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "logiq-flash.fullname" . }}
                   key: postgres_db
+            {{- if .Values.global.sharedSecretName }}
             - name: S3_ACCESS
               valueFrom:
                 secretKeyRef:
@@ -264,6 +265,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.sharedSecretName }}
                   key: s3_bucket
+            {{- end }}
             {{- if .Values.global.environment.cluster_id }}
             - name: MY_CLUSTER_ID
               value: {{ .Values.global.environment.cluster_id }}
@@ -456,6 +458,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "logiq-flash.fullname" . }}
                   key: postgres_db
+            {{- if .Values.global.sharedSecretName }}
             - name: S3_ACCESS
               valueFrom:
                 secretKeyRef:
@@ -471,6 +474,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.sharedSecretName }}
                   key: s3_bucket
+            {{- end }}
             {{- if .Values.global.environment.cluster_id }}
             - name: MY_CLUSTER_ID
               value: {{ .Values.global.environment.cluster_id }}

--- a/apica-ascent/charts/logiq-flash/templates/statefulset-ml.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulset-ml.yaml
@@ -15,18 +15,29 @@ spec:
     matchLabels:
       app: {{ template "logiq-flash.name" . }}-ml
       release: {{ .Release.Name }}
+
+  # ── Feature 4 ── Rolling update: only 1 pod unavailable at a time.
+  # StatefulSet updates proceed pod-by-pod (highest ordinal first).
+  # The readinessProbe on /ready gates traffic so old pods keep serving
+  # until the new pod is fully ready.
+  updateStrategy:
+    type: {{ .Values.ml.updateStrategy.type }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.ml.updateStrategy.maxUnavailable }}
+
   volumeClaimTemplates:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: data
-    spec:
-      accessModes:
-        - ReadWriteOnce
-      resources:
-        requests:
-          storage: {{ .Values.persistence.ml_size | quote }}
-      storageClassName: {{ .Values.global.persistence.storageClass }}
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.persistence.ml_size | quote }}
+        storageClassName: {{ .Values.global.persistence.storageClass }}
+
   template:
     metadata:
       annotations:
@@ -36,190 +47,266 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: logiq-flash
+
+      # ── Feature 5 ── Graceful shutdown budget.
+      # Kubernetes removes the pod from endpoints and sends SIGTERM simultaneously.
+      # The preStop sleep gives the load-balancer time to drain connections before
+      # the process receives SIGTERM. terminationGracePeriodSeconds is the hard
+      # ceiling for the entire shutdown sequence (preStop + SIGTERM handling).
+      terminationGracePeriodSeconds: {{ .Values.ml.terminationGracePeriodSeconds }}
+
+      # ── Feature 1 ── Topology spread constraints (soft, ScheduleAnyway).
+      # Two constraints: spread across hostnames (nodes) AND across zones.
+      # ScheduleAnyway means a pod is never left Pending due to topology skew.
+      {{- if .Values.ml.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.ml.topologySpreadConstraints.maxSkew }}
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: {{ .Values.ml.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ template "logiq-flash.name" . }}-ml
+              release: {{ .Release.Name }}
+        - maxSkew: {{ .Values.ml.topologySpreadConstraints.maxSkew }}
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: {{ .Values.ml.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ template "logiq-flash.name" . }}-ml
+              release: {{ .Release.Name }}
+      {{- end }}
+
       securityContext:
         fsGroup: 1000
         runAsUser: 1000
         runAsGroup: 1000
+
+      affinity:
+        {{- if .Values.global.nodeSelectors.enabled }}
+        # Node affinity: hard requirement to land on the correct node pool.
+        # Unchanged from original — uses global.nodeSelectors.other label.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: {{ .Values.global.nodeSelectors.label }}
+                    operator: In
+                    values:
+                      - {{ .Values.global.nodeSelectors.other }}
+        {{- end }}
+
+        # ── Feature 2 ── Preferred pod anti-affinity (weight 100).
+        # Adds strong scheduling pressure to avoid co-locating ML replicas on the
+        # same node WITHOUT ever blocking scheduling (preferred, not required).
+        # Never use requiredDuringScheduling here — it causes Pending pods when
+        # nodes < replicas.
+        {{- if .Values.ml.podAntiAffinity.enabled }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: {{ .Values.ml.podAntiAffinity.weight }}
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: {{ template "logiq-flash.name" . }}-ml
+                    release: {{ .Release.Name }}
+        {{- end }}
+
+      {{- if .Values.global.taints.enabled }}
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: {{ .Values.global.taints.other }}
+          effect: NoSchedule
+      {{- end }}
+
       initContainers:
-      - name: check-redis
-        image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
-        imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - until redis-cli -h {{ .Values.global.environment.redis_host }} ping; do echo "waiting for {{ .Values.global.environment.redis_host }}"; sleep 1;
-          done;
-{{ if .Values.global.chart.s3gateway }}          
-      - command:
-          - sh
-          - -c
-          - until $(curl --output /dev/null --silent --fail http://s3-gateway:9000/minio/health/ready); do echo "waiting for s3-gateway"; sleep 1;
-            done;
-        image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
-        imagePullPolicy: IfNotPresent
-        name: check-s3-gateway
-{{ end }}        
-      - command:
-        - sh
-        - -c
-        - until $(curl --output /dev/null --silent --fail http://logiq-flash:8080/ready); do echo "waiting for flash"; sleep 1;
-          done;
-        image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
-        imagePullPolicy: IfNotPresent
-        name: check-flash
+        - name: check-redis
+          image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+              until redis-cli -h {{ .Values.global.environment.redis_host }} ping;
+              do echo "waiting for {{ .Values.global.environment.redis_host }}"; sleep 1; done;
+
+        {{- if .Values.global.chart.s3gateway }}
+        - name: check-s3-gateway
+          image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+              until $(curl --output /dev/null --silent --fail http://s3-gateway:9000/minio/health/ready);
+              do echo "waiting for s3-gateway"; sleep 1; done;
+        {{- end }}
+
+        - name: check-flash
+          image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+              until $(curl --output /dev/null --silent --fail http://logiq-flash:8080/ready);
+              do echo "waiting for flash"; sleep 1; done;
+
       volumes:
-        {{ if .Values.configurationFiles }}
+        {{- if .Values.configurationFiles }}
         - name: config
           configMap:
-            {{ if not .Values.configMapName }}
+            {{- if not .Values.configMapName }}
             name: logiq-config
-            {{ else }}
+            {{- else }}
             name: {{ .Values.configMapName }}
-            {{ end }}
-        {{ end }}
-        {{ if .Values.secrets_name }}
+            {{- end }}
+        {{- end }}
+        {{- if .Values.secrets_name }}
         - name: certs
           secret:
             secretName: {{ .Values.secrets_name }}
-        {{ end }}
-        {{ if .Values.global.sharedSecretName }}
+        {{- end }}
+        {{- if .Values.global.sharedSecretName }}
         - name: sharedcert
           secret:
             secretName: {{ .Values.global.sharedSecretName }}
-        {{ end }}
-      {{ if .Values.podPerNode }}
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - {{ template "logiq-flash.name" . }}
-            topologyKey: "kubernetes.io/hostname"
-      {{ end }}
+        {{- end }}
+
       containers:
         - name: {{ .Chart.Name }}-ml
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-          - -c
-          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -is-kube=true -discovery_domain=$(DISCOVERY_DOMAIN) -pg_max_idle_conns 3 -pg_max_open_Conns 5 -metadata-db-ttl 11m -postgres_timeout 20s -api-node  -redis_max_connections 3000 --pg_conn_max_lifetime 5m -ml-use-sidecar {{ .Values.global.environment.extraflag }}
           command:
-          - /bin/bash
+            - /bin/bash
+          args:
+            - -c
+            - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -is-kube=true -discovery_domain=$(DISCOVERY_DOMAIN) -pg_max_idle_conns 3 -pg_max_open_Conns 5 -metadata-db-ttl 11m -postgres_timeout 20s -api-node  -redis_max_connections 3000 --pg_conn_max_lifetime 5m -ml-use-sidecar {{ .Values.global.environment.extraflag }}
+
+          # ── Feature 5 (continued) ── preStop hook.
+          # Sleeps for preStopSleepSeconds before the container receives SIGTERM,
+          # giving the kube-proxy / cloud LB time to remove this pod from the
+          # active endpoint slice and stop routing new requests to it.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep {{ .Values.ml.preStopSleepSeconds }}"]
+
           env:
-          - name: host
-            value: {{.Values.global.domain}}
-          - name: CONFIG_HASH
-            value: {{ include "logiq-flash.confighash" . | quote }}
-          - name: DISCOVERY_DOMAIN
-            value: {{ template "logiq-flash.name" . }}-ml
-          {{ if .Values.global.environment.parent_host }}  
-          - name: PARENT_HOST
-            value: {{ .Values.global.environment.parent_host }}
-          {{ end }}
-          {{ if .Values.global.environment.redis_opts }}
-          - name: REDIS_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: redis_host
-          - name: REDIS_PORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: redis_port
-          {{ end }}
-          {{ if .Values.global.environment.admin_email }}
-          - name: ADMIN_EMAIL
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: admin_email
-          {{ end }}
-          {{ if .Values.global.environment.admin_password }}
-          - name: ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: admin_password
-          {{ end }}
-          - name: POSTGRES_USER
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_user
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_password
-          - name: POSTGRES_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_host
-          - name: POSTGRES_PORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_port
-          - name: POSTGRES_DB
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_db
-          - name: S3_ACCESS
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_access
-          - name: S3_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_secret
-          - name: S3_BUCKET
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_bucket
-          {{ if .Values.global.environment.cluster_id }}  
-          - name: MY_CLUSTER_ID
-            value: {{ .Values.global.environment.cluster_id }}
-          {{ end }}
-          - name: MY_APP_NAME
-            value: {{ template "logiq-flash.name" . }}-ml
-          - name: MY_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: MY_POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
+            - name: host
+              value: {{ .Values.global.domain }}
+            - name: CONFIG_HASH
+              value: {{ include "logiq-flash.confighash" . | quote }}
+            - name: DISCOVERY_DOMAIN
+              value: {{ template "logiq-flash.name" . }}-ml
+            {{- if .Values.global.environment.parent_host }}
+            - name: PARENT_HOST
+              value: {{ .Values.global.environment.parent_host }}
+            {{- end }}
+            {{- if .Values.global.environment.redis_opts }}
+            - name: REDIS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: redis_host
+            - name: REDIS_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: redis_port
+            {{- end }}
+            {{- if .Values.global.environment.admin_email }}
+            - name: ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: admin_email
+            {{- end }}
+            {{- if .Values.global.environment.admin_password }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: admin_password
+            {{- end }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_password
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_host
+            - name: POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_port
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_db
+            - name: S3_ACCESS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_access
+            - name: S3_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_secret
+            - name: S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_bucket
+            {{- if .Values.global.environment.cluster_id }}
+            - name: MY_CLUSTER_ID
+              value: {{ .Values.global.environment.cluster_id }}
+            {{- end }}
+            - name: MY_APP_NAME
+              value: {{ template "logiq-flash.name" . }}-ml
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+
           volumeMounts:
-          - mountPath: /flash/config
-            name: config
-          - mountPath: /flash/db
-            name: data
-          {{ if .Values.secrets_name }}
-          - mountPath: /flash/certs
-            name: certs
-          {{ end }}
-          {{ if .Values.global.sharedSecretName }}
-          - mountPath: /flash/sharedcerts
-            name: sharedcert
-          {{ end }}
+            - mountPath: /flash/config
+              name: config
+            - mountPath: /flash/db
+              name: data
+            {{- if .Values.secrets_name }}
+            - mountPath: /flash/certs
+              name: certs
+            {{- end }}
+            {{- if .Values.global.sharedSecretName }}
+            - mountPath: /flash/sharedcerts
+              name: sharedcert
+            {{- end }}
+
           ports:
             - name: grpc
               containerPort: 50054
@@ -233,70 +320,62 @@ spec:
             - name: healthcheck
               containerPort: 8080
               protocol: TCP
+
+          # ── Feature 4 (continued) ── Readiness probe gates rollout traffic.
+          # A pod is only added to the endpoint slice once /ready returns 200.
+          # During a rolling update the old pod keeps serving until the new pod
+          # passes its readiness check.
           readinessProbe:
             httpGet:
               path: /ready
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 25
+            timeoutSeconds: 125
             successThreshold: 1
             failureThreshold: 3
-            timeoutSeconds: 125
+
+          # Liveness probe: restart the container if /ready stops returning 200.
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+
           resources:
-{{ toYaml .Values.resources.ml | indent 12 }}
+            {{- toYaml .Values.resources.ml | nindent 12 }}
+
         - name: {{ .Chart.Name }}-tracing
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.sidecarTracingMl.image }}:{{ .Values.sidecarTracingMl.tag }}"
           imagePullPolicy: {{ .Values.sidecarTracingMl.pullPolicy }}
           command:
-          - /bin/sh
-          - -c
-          - |
-            while true 
-            do   
-            /go/bin/query-linux --grpc-storage.server=localhost:50054 --query.bearer-token-propagation=true --query.base-path=/dtracing
-            sleep 5
-            done
-          env:          
-          - name: SPAN_STORAGE_TYPE
-            value: grpc-plugin
+            - /bin/sh
+            - -c
+            - |
+              while true
+              do
+              /go/bin/query-linux --grpc-storage.server=localhost:50054 --query.bearer-token-propagation=true --query.base-path=/dtracing
+              sleep 5
+              done
+          env:
+            - name: SPAN_STORAGE_TYPE
+              value: grpc-plugin
           ports:
-          - containerPort: 16686
-            name: tracing
-            protocol: TCP
+            - containerPort: 16686
+              name: tracing
+              protocol: TCP
           readinessProbe:
             httpGet:
               path: /dtracing
               port: 16686
             initialDelaySeconds: 25
             periodSeconds: 25
+            timeoutSeconds: 125
             successThreshold: 1
             failureThreshold: 3
-            timeoutSeconds: 125
           resources:
-{{ toYaml .Values.resources.sidecarMlTracing | indent 12 }}
-    {{ with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{ end }}
-    {{ with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{ end }}
-      {{- if .Values.global.nodeSelectors.enabled }}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                - key: {{ .Values.global.nodeSelectors.label }}
-                  operator: In
-                  values:
-                    - {{ .Values.global.nodeSelectors.other }}
-      {{- end }}
-      {{- if .Values.global.taints.enabled }}
-      tolerations:
-      - key: dedicated
-        operator: Equal
-        value: {{ .Values.global.taints.other }}
-        effect: NoSchedule
-      {{- end }}
+            {{- toYaml .Values.resources.sidecarMlTracing | nindent 12 }}

--- a/apica-ascent/charts/logiq-flash/templates/statefulset-ml.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulset-ml.yaml
@@ -230,6 +230,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "logiq-flash.fullname" . }}
                   key: postgres_db
+            {{- if .Values.global.sharedSecretName }}
             - name: S3_ACCESS
               valueFrom:
                 secretKeyRef:
@@ -245,6 +246,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.sharedSecretName }}
                   key: s3_bucket
+            {{- end }}
             {{- if .Values.global.environment.cluster_id }}
             - name: MY_CLUSTER_ID
               value: {{ .Values.global.environment.cluster_id }}

--- a/apica-ascent/charts/logiq-flash/templates/statefulset-ml.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulset-ml.yaml
@@ -15,16 +15,11 @@ spec:
     matchLabels:
       app: {{ template "logiq-flash.name" . }}-ml
       release: {{ .Release.Name }}
-
-  # ── Feature 4 ── Rolling update: only 1 pod unavailable at a time.
-  # StatefulSet updates proceed pod-by-pod (highest ordinal first).
-  # The readinessProbe on /ready gates traffic so old pods keep serving
-  # until the new pod is fully ready.
+  # Rolling update: 1 pod down at a time; readinessProbe gates traffic during rollout.
   updateStrategy:
     type: {{ .Values.ml.updateStrategy.type }}
     rollingUpdate:
       maxUnavailable: {{ .Values.ml.updateStrategy.maxUnavailable }}
-
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
@@ -37,7 +32,6 @@ spec:
           requests:
             storage: {{ .Values.persistence.ml_size | quote }}
         storageClassName: {{ .Values.global.persistence.storageClass }}
-
   template:
     metadata:
       annotations:
@@ -47,17 +41,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: logiq-flash
-
-      # ── Feature 5 ── Graceful shutdown budget.
-      # Kubernetes removes the pod from endpoints and sends SIGTERM simultaneously.
-      # The preStop sleep gives the load-balancer time to drain connections before
-      # the process receives SIGTERM. terminationGracePeriodSeconds is the hard
-      # ceiling for the entire shutdown sequence (preStop + SIGTERM handling).
+      # preStop(15s) fills the LB-drain gap before SIGTERM; 60s is the hard ceiling.
       terminationGracePeriodSeconds: {{ .Values.ml.terminationGracePeriodSeconds }}
 
-      # ── Feature 1 ── Topology spread constraints (soft, ScheduleAnyway).
-      # Two constraints: spread across hostnames (nodes) AND across zones.
-      # ScheduleAnyway means a pod is never left Pending due to topology skew.
+      # Zone-only spread — ScheduleAnyway never blocks scheduling.
       {{- if .Values.ml.topologySpreadConstraints.enabled }}
       topologySpreadConstraints:
         - maxSkew: {{ .Values.ml.topologySpreadConstraints.maxSkew }}
@@ -83,8 +70,6 @@ spec:
 
       affinity:
         {{- if .Values.global.nodeSelectors.enabled }}
-        # Node affinity: hard requirement to land on the correct node pool.
-        # Unchanged from original — uses global.nodeSelectors.other label.
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -94,12 +79,7 @@ spec:
                     values:
                       - {{ .Values.global.nodeSelectors.other }}
         {{- end }}
-
-        # ── Feature 2 ── Preferred pod anti-affinity (weight 100).
-        # Adds strong scheduling pressure to avoid co-locating ML replicas on the
-        # same node WITHOUT ever blocking scheduling (preferred, not required).
-        # Never use requiredDuringScheduling here — it causes Pending pods when
-        # nodes < replicas.
+        # Preferred anti-affinity: adds scheduling pressure without ever blocking.
         {{- if .Values.ml.podAntiAffinity.enabled }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -183,16 +163,11 @@ spec:
           args:
             - -c
             - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -is-kube=true -discovery_domain=$(DISCOVERY_DOMAIN) -pg_max_idle_conns 3 -pg_max_open_Conns 5 -metadata-db-ttl 11m -postgres_timeout 20s -api-node  -redis_max_connections 3000 --pg_conn_max_lifetime 5m -ml-use-sidecar {{ .Values.global.environment.extraflag }}
-
-          # ── Feature 5 (continued) ── preStop hook.
-          # Sleeps for preStopSleepSeconds before the container receives SIGTERM,
-          # giving the kube-proxy / cloud LB time to remove this pod from the
-          # active endpoint slice and stop routing new requests to it.
+          # Sleep before SIGTERM so the LB stops routing before the process exits.
           lifecycle:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep {{ .Values.ml.preStopSleepSeconds }}"]
-
           env:
             - name: host
               value: {{ .Values.global.domain }}
@@ -321,10 +296,6 @@ spec:
               containerPort: 8080
               protocol: TCP
 
-          # ── Feature 4 (continued) ── Readiness probe gates rollout traffic.
-          # A pod is only added to the endpoint slice once /ready returns 200.
-          # During a rolling update the old pod keeps serving until the new pod
-          # passes its readiness check.
           readinessProbe:
             httpGet:
               path: /ready
@@ -335,7 +306,6 @@ spec:
             successThreshold: 1
             failureThreshold: 3
 
-          # Liveness probe: restart the container if /ready stops returning 200.
           livenessProbe:
             httpGet:
               path: /ready
@@ -368,6 +338,7 @@ spec:
             - containerPort: 16686
               name: tracing
               protocol: TCP
+
           readinessProbe:
             httpGet:
               path: /dtracing
@@ -378,10 +349,7 @@ spec:
             successThreshold: 1
             failureThreshold: 3
 
-          # Liveness probe: restart the tracing sidecar if /dtracing stops responding.
-          # timeoutSeconds matches readinessProbe (125s) — the Jaeger query process
-          # can be slow to respond under load; a shorter timeout would cause false
-          # restarts and is the likely reason the original readiness used 125s.
+          # timeoutSeconds: 125 matches readiness — Jaeger query can be slow under load.
           livenessProbe:
             httpGet:
               path: /dtracing

--- a/apica-ascent/charts/logiq-flash/templates/statefulset-ml.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulset-ml.yaml
@@ -377,5 +377,20 @@ spec:
             timeoutSeconds: 125
             successThreshold: 1
             failureThreshold: 3
+
+          # Liveness probe: restart the tracing sidecar if /dtracing stops responding.
+          # timeoutSeconds matches readinessProbe (125s) — the Jaeger query process
+          # can be slow to respond under load; a shorter timeout would cause false
+          # restarts and is the likely reason the original readiness used 125s.
+          livenessProbe:
+            httpGet:
+              path: /dtracing
+              port: 16686
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 125
+            successThreshold: 1
+            failureThreshold: 3
+
           resources:
             {{- toYaml .Values.resources.sidecarMlTracing | nindent 12 }}

--- a/apica-ascent/charts/logiq-flash/templates/statefulset-sync.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulset-sync.yaml
@@ -15,16 +15,11 @@ spec:
     matchLabels:
       app: {{ template "logiq-flash.name" . }}-sync
       release: {{ .Release.Name }}
-
-  # ── Feature 4 ── Rolling update: only 1 pod unavailable at a time.
-  # StatefulSet updates proceed pod-by-pod (highest ordinal first).
-  # The readinessProbe on /ready gates traffic so old pods keep serving
-  # until the new pod is fully ready.
+  # Rolling update: 1 pod down at a time; readinessProbe gates traffic during rollout.
   updateStrategy:
     type: {{ .Values.sync.updateStrategy.type }}
     rollingUpdate:
       maxUnavailable: {{ .Values.sync.updateStrategy.maxUnavailable }}
-
   template:
     metadata:
       annotations:
@@ -34,17 +29,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: logiq-flash
-
-      # ── Feature 5 ── Graceful shutdown budget.
-      # Kubernetes removes the pod from endpoints and sends SIGTERM simultaneously.
-      # The preStop sleep gives the load-balancer time to drain connections before
-      # the process receives SIGTERM. terminationGracePeriodSeconds is the hard
-      # ceiling for the entire shutdown sequence (preStop + SIGTERM handling).
+      # preStop(15s) fills the LB-drain gap before SIGTERM; 60s is the hard ceiling.
       terminationGracePeriodSeconds: {{ .Values.sync.terminationGracePeriodSeconds }}
 
-      # ── Feature 1 ── Topology spread constraints (soft, ScheduleAnyway).
-      # Two constraints: spread across hostnames (nodes) AND across zones.
-      # ScheduleAnyway means a pod is never left Pending due to topology skew.
+      # Soft spread across nodes and zones — ScheduleAnyway never blocks scheduling.
       {{- if .Values.sync.topologySpreadConstraints.enabled }}
       topologySpreadConstraints:
         - maxSkew: {{ .Values.sync.topologySpreadConstraints.maxSkew }}
@@ -70,8 +58,6 @@ spec:
 
       affinity:
         {{- if .Values.global.nodeSelectors.enabled }}
-        # Node affinity: hard requirement to land on the correct node pool.
-        # Unchanged from original — uses global.nodeSelectors.ingest_sync label.
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -81,12 +67,7 @@ spec:
                     values:
                       - {{ .Values.global.nodeSelectors.ingest_sync }}
         {{- end }}
-
-        # ── Feature 2 ── Preferred pod anti-affinity (weight 100).
-        # Adds strong scheduling pressure to avoid co-locating sync replicas on the
-        # same node WITHOUT ever blocking scheduling (preferred, not required).
-        # Never use requiredDuringScheduling here — it causes Pending pods when
-        # nodes < replicas.
+        # Preferred anti-affinity: adds scheduling pressure without ever blocking.
         {{- if .Values.sync.podAntiAffinity.enabled }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -172,16 +153,11 @@ spec:
           args:
             - -c
             - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -is-kube=true -discovery_domain=$(DISCOVERY_DOMAIN) -pg_max_idle_conns 3 -pg_max_open_Conns 5 -postgres_timeout 40s -metadata-db-ttl 11m -metadata-text-upload-jobs 50 -sync-node
-
-          # ── Feature 5 (continued) ── preStop hook.
-          # Sleeps for preStopSleepSeconds before the container receives SIGTERM,
-          # giving the kube-proxy / cloud LB time to remove this pod from the
-          # active endpoint slice and stop routing new requests to it.
+          # Sleep before SIGTERM so the LB stops routing before the process exits.
           lifecycle:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep {{ .Values.sync.preStopSleepSeconds }}"]
-
           env:
             - name: CONFIG_HASH
               value: {{ include "logiq-flash.confighash" . | quote }}
@@ -308,10 +284,6 @@ spec:
               containerPort: 8080
               protocol: TCP
 
-          # ── Feature 4 (continued) ── Readiness probe gates rollout traffic.
-          # A pod is only added to the endpoint slice once /ready returns 200.
-          # During a rolling update the old pod keeps serving until the new pod
-          # passes its readiness check.
           readinessProbe:
             httpGet:
               path: /ready
@@ -322,7 +294,6 @@ spec:
             successThreshold: 1
             failureThreshold: 3
 
-          # Liveness probe: restart the container if /ready stops returning 200.
           livenessProbe:
             httpGet:
               path: /ready

--- a/apica-ascent/charts/logiq-flash/templates/statefulset-sync.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulset-sync.yaml
@@ -15,6 +15,16 @@ spec:
     matchLabels:
       app: {{ template "logiq-flash.name" . }}-sync
       release: {{ .Release.Name }}
+
+  # ── Feature 4 ── Rolling update: only 1 pod unavailable at a time.
+  # StatefulSet updates proceed pod-by-pod (highest ordinal first).
+  # The readinessProbe on /ready gates traffic so old pods keep serving
+  # until the new pod is fully ready.
+  updateStrategy:
+    type: {{ .Values.sync.updateStrategy.type }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.sync.updateStrategy.maxUnavailable }}
+
   template:
     metadata:
       annotations:
@@ -24,190 +34,266 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: logiq-flash
+
+      # ── Feature 5 ── Graceful shutdown budget.
+      # Kubernetes removes the pod from endpoints and sends SIGTERM simultaneously.
+      # The preStop sleep gives the load-balancer time to drain connections before
+      # the process receives SIGTERM. terminationGracePeriodSeconds is the hard
+      # ceiling for the entire shutdown sequence (preStop + SIGTERM handling).
+      terminationGracePeriodSeconds: {{ .Values.sync.terminationGracePeriodSeconds }}
+
+      # ── Feature 1 ── Topology spread constraints (soft, ScheduleAnyway).
+      # Two constraints: spread across hostnames (nodes) AND across zones.
+      # ScheduleAnyway means a pod is never left Pending due to topology skew.
+      {{- if .Values.sync.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.sync.topologySpreadConstraints.maxSkew }}
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: {{ .Values.sync.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ template "logiq-flash.name" . }}-sync
+              release: {{ .Release.Name }}
+        - maxSkew: {{ .Values.sync.topologySpreadConstraints.maxSkew }}
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: {{ .Values.sync.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ template "logiq-flash.name" . }}-sync
+              release: {{ .Release.Name }}
+      {{- end }}
+
       securityContext:
         fsGroup: 1000
         runAsUser: 1000
         runAsGroup: 1000
+
+      affinity:
+        {{- if .Values.global.nodeSelectors.enabled }}
+        # Node affinity: hard requirement to land on the correct node pool.
+        # Unchanged from original — uses global.nodeSelectors.ingest_sync label.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: {{ .Values.global.nodeSelectors.label }}
+                    operator: In
+                    values:
+                      - {{ .Values.global.nodeSelectors.ingest_sync }}
+        {{- end }}
+
+        # ── Feature 2 ── Preferred pod anti-affinity (weight 100).
+        # Adds strong scheduling pressure to avoid co-locating sync replicas on the
+        # same node WITHOUT ever blocking scheduling (preferred, not required).
+        # Never use requiredDuringScheduling here — it causes Pending pods when
+        # nodes < replicas.
+        {{- if .Values.sync.podAntiAffinity.enabled }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: {{ .Values.sync.podAntiAffinity.weight }}
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: {{ template "logiq-flash.name" . }}-sync
+                    release: {{ .Release.Name }}
+        {{- end }}
+
+      {{- if .Values.global.taints.enabled }}
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: {{ .Values.global.taints.ingest_sync }}
+          effect: NoSchedule
+      {{- end }}
+
       initContainers:
-      - command:
-        - sh
-        - -c
-        - until $(curl --output /dev/null --silent --fail http://logiq-flash:8080/ready); do echo "waiting for flash"; sleep 1;
-          done;
-        image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
-        imagePullPolicy: IfNotPresent
-        name: check-flash
-      - name: check-redis
-        image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
-        imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - until redis-cli -h {{ .Values.global.environment.redis_host }} ping; do echo "waiting for {{ .Values.global.environment.redis_host }}"; sleep 1;
-          done;
-{{ if .Values.global.chart.s3gateway }}                 
-      - command:
-          - sh
-          - -c
-          - until $(curl --output /dev/null --silent --fail http://s3-gateway:9000/minio/health/ready); do echo "waiting for s3-gateway"; sleep 1;
-            done;
-        image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
-        imagePullPolicy: IfNotPresent
-        name: check-s3-gateway
-{{ end }}            
+        - name: check-flash
+          image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+              until $(curl --output /dev/null --silent --fail http://logiq-flash:8080/ready);
+              do echo "waiting for flash"; sleep 1; done;
+
+        - name: check-redis
+          image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+              until redis-cli -h {{ .Values.global.environment.redis_host }} ping;
+              do echo "waiting for {{ .Values.global.environment.redis_host }}"; sleep 1; done;
+
+        {{- if .Values.global.chart.s3gateway }}
+        - name: check-s3-gateway
+          image: {{ .Values.global.imageRegistry }}/{{ .Values.global.toolbox.image.repository }}:{{ .Values.global.toolbox.image.tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+              until $(curl --output /dev/null --silent --fail http://s3-gateway:9000/minio/health/ready);
+              do echo "waiting for s3-gateway"; sleep 1; done;
+        {{- end }}
+
       volumes:
-        {{ if .Values.configurationFiles }}
+        {{- if .Values.configurationFiles }}
         - name: config
           configMap:
-            {{ if not .Values.configMapName }}
+            {{- if not .Values.configMapName }}
             name: logiq-config
-            {{ else }}
+            {{- else }}
             name: {{ .Values.configMapName }}
-            {{ end }}
-        {{ end }}
-        {{ if .Values.secrets_name }}
+            {{- end }}
+        {{- end }}
+        {{- if .Values.secrets_name }}
         - name: certs
           secret:
             secretName: {{ .Values.secrets_name }}
-        {{ end }}
-        {{ if .Values.global.sharedSecretName }}
+        {{- end }}
+        {{- if .Values.global.sharedSecretName }}
         - name: sharedcert
           secret:
             secretName: {{ .Values.global.sharedSecretName }}
-        {{ end }}
+        {{- end }}
         - name: data
           emptyDir: {}
-      {{ if .Values.podPerNode }}
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - {{ template "logiq-flash.name" . }}
-            topologyKey: "kubernetes.io/hostname"
-      {{ end }}
+
       containers:
         - name: {{ .Chart.Name }}-sync
           image: "{{ .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-          - -c
-          - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -is-kube=true -discovery_domain=$(DISCOVERY_DOMAIN) -pg_max_idle_conns 3 -pg_max_open_Conns 5 -postgres_timeout 40s -metadata-db-ttl 11m -metadata-text-upload-jobs 50 -sync-node
           command:
-          - /bin/bash
+            - /bin/bash
+          args:
+            - -c
+            - /flash/bin/flash -config /flash/config/config.yaml -install_root /flash -runtime_folder /flash/db -is-kube=true -discovery_domain=$(DISCOVERY_DOMAIN) -pg_max_idle_conns 3 -pg_max_open_Conns 5 -postgres_timeout 40s -metadata-db-ttl 11m -metadata-text-upload-jobs 50 -sync-node
+
+          # ── Feature 5 (continued) ── preStop hook.
+          # Sleeps for preStopSleepSeconds before the container receives SIGTERM,
+          # giving the kube-proxy / cloud LB time to remove this pod from the
+          # active endpoint slice and stop routing new requests to it.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep {{ .Values.sync.preStopSleepSeconds }}"]
+
           env:
-          - name: CONFIG_HASH
-            value: {{ include "logiq-flash.confighash" . | quote }}
-          - name: DISCOVERY_DOMAIN
-            value: {{ template "logiq-flash.name" . }}-sync
-          {{ if .Values.global.environment.parent_host }}  
-          - name: PARENT_HOST
-            value: {{ .Values.global.environment.parent_host }}
-          {{ end }}
-          {{ if .Values.global.environment.redis_opts }}
-          - name: REDIS_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: redis_host
-          - name: REDIS_PORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: redis_port
-          {{ end }}
-          {{ if .Values.global.environment.admin_email }}
-          - name: ADMIN_EMAIL
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: admin_email
-          {{ end }}
-          {{ if .Values.global.environment.admin_password }}
-          - name: ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: admin_password
-          {{ end }}
-          - name: POSTGRES_USER
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_user
-          - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_password
-          - name: POSTGRES_HOST
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_host
-          - name: POSTGRES_PORT
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_port
-          - name: POSTGRES_DB
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "logiq-flash.fullname" . }}
-                key: postgres_db
-          - name: S3_ACCESS
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_access
-          - name: S3_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_secret
-          - name: S3_BUCKET
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.global.sharedSecretName  }}
-                key: s3_bucket
-          {{ if .Values.global.environment.cluster_id }}  
-          - name: MY_CLUSTER_ID
-            value: {{ .Values.global.environment.cluster_id }}
-          {{ end }}
-          - name: MY_APP_NAME
-            value: {{ template "logiq-flash.name" . }}-sync
-          - name: MY_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: MY_POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
+            - name: CONFIG_HASH
+              value: {{ include "logiq-flash.confighash" . | quote }}
+            - name: DISCOVERY_DOMAIN
+              value: {{ template "logiq-flash.name" . }}-sync
+            {{- if .Values.global.environment.parent_host }}
+            - name: PARENT_HOST
+              value: {{ .Values.global.environment.parent_host }}
+            {{- end }}
+            {{- if .Values.global.environment.redis_opts }}
+            - name: REDIS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: redis_host
+            - name: REDIS_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: redis_port
+            {{- end }}
+            {{- if .Values.global.environment.admin_email }}
+            - name: ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: admin_email
+            {{- end }}
+            {{- if .Values.global.environment.admin_password }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: admin_password
+            {{- end }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_password
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_host
+            - name: POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_port
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "logiq-flash.fullname" . }}
+                  key: postgres_db
+            - name: S3_ACCESS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_access
+            - name: S3_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_secret
+            - name: S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.sharedSecretName }}
+                  key: s3_bucket
+            {{- if .Values.global.environment.cluster_id }}
+            - name: MY_CLUSTER_ID
+              value: {{ .Values.global.environment.cluster_id }}
+            {{- end }}
+            - name: MY_APP_NAME
+              value: {{ template "logiq-flash.name" . }}-sync
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+
           volumeMounts:
-          - mountPath: /flash/config
-            name: config
-          - mountPath: /flash/db
-            name: data
-          {{ if .Values.secrets_name }}
-          - mountPath: /flash/certs
-            name: certs
-          {{ end }}
-          {{ if .Values.global.sharedSecretName }}
-          - mountPath: /flash/sharedcerts
-            name: sharedcert
-          {{ end }}
+            - mountPath: /flash/config
+              name: config
+            - mountPath: /flash/db
+              name: data
+            {{- if .Values.secrets_name }}
+            - mountPath: /flash/certs
+              name: certs
+            {{- end }}
+            {{- if .Values.global.sharedSecretName }}
+            - mountPath: /flash/sharedcerts
+              name: sharedcert
+            {{- end }}
+
           ports:
             - name: grpc
               containerPort: 50054
@@ -221,40 +307,31 @@ spec:
             - name: healthcheck
               containerPort: 8080
               protocol: TCP
+
+          # ── Feature 4 (continued) ── Readiness probe gates rollout traffic.
+          # A pod is only added to the endpoint slice once /ready returns 200.
+          # During a rolling update the old pod keeps serving until the new pod
+          # passes its readiness check.
           readinessProbe:
             httpGet:
               path: /ready
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 25
+            timeoutSeconds: 125
             successThreshold: 1
             failureThreshold: 3
-            timeoutSeconds: 125
+
+          # Liveness probe: restart the container if /ready stops returning 200.
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+
           resources:
-{{ toYaml .Values.resources.sync | indent 12 }}
-    {{ with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{ end }}
-    {{ with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{ end }}
-{{ if .Values.global.nodeSelectors.enabled }}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                - key: {{ .Values.global.nodeSelectors.label }}
-                  operator: In
-                  values:
-                    - {{ .Values.global.nodeSelectors.ingest_sync }}
-{{ end }}
-{{ if .Values.global.taints.enabled}}
-      tolerations:
-      - key: dedicated
-        operator: Equal
-        value: {{ .Values.global.taints.ingest_sync }}
-        effect: NoSchedule
-{{ end }}
+            {{- toYaml .Values.resources.sync | nindent 12 }}

--- a/apica-ascent/charts/logiq-flash/templates/statefulset-sync.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulset-sync.yaml
@@ -218,6 +218,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "logiq-flash.fullname" . }}
                   key: postgres_db
+            {{- if .Values.global.sharedSecretName }}
             - name: S3_ACCESS
               valueFrom:
                 secretKeyRef:
@@ -233,6 +234,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.sharedSecretName }}
                   key: s3_bucket
+            {{- end }}
             {{- if .Values.global.environment.cluster_id }}
             - name: MY_CLUSTER_ID
               value: {{ .Values.global.environment.cluster_id }}

--- a/apica-ascent/charts/logiq-flash/values.yaml
+++ b/apica-ascent/charts/logiq-flash/values.yaml
@@ -6,92 +6,56 @@ replicaCount: 2
 replicaCountMl: 2
 replicaCountSync: 2
 
-# ── High-availability scheduling controls for logiq-flash-sync ─────────────────
-
-# Feature 1: topologySpreadConstraints — soft spread across nodes and zones.
 sync:
   topologySpreadConstraints:
     enabled: true
     maxSkew: 1
-    whenUnsatisfiable: ScheduleAnyway
-
-  # Feature 2: preferred pod anti-affinity — weight 100, never blocks scheduling.
+    whenUnsatisfiable: ScheduleAnyway   # soft — never blocks scheduling
   podAntiAffinity:
     enabled: true
     weight: 100
-
-  # Feature 4: rolling update — 1 pod unavailable at a time.
   updateStrategy:
     type: RollingUpdate
     maxUnavailable: 1
-
-  # Feature 5: graceful shutdown — preStop(15s) fills LB-drain gap before SIGTERM.
   terminationGracePeriodSeconds: 60
   preStopSleepSeconds: 15
-
-  # Feature 3: PodDisruptionBudget — keep N-1 pods alive during drains/upgrades.
-  # Root values.yaml sets replicaCountSync=2 → minAvailable=1 (N-1).
+  # N-1 for replicaCountSync=2
   pdb:
     enabled: true
     minAvailable: 1
 
-# ── High-availability scheduling controls for logiq-flash (primary ingest) ─────
-#
-# NOTE: logiq-flash uses a hard podAntiAffinity (podPerNode) that already
-# guarantees one-pod-per-node. The hostname topologySpreadConstraint and a
-# preferred podAntiAffinity on hostname are both omitted — they would be
-# redundant with the hard rule. Only the zone constraint adds new value.
+# Zone-only spread — hard podAntiAffinity (podPerNode) already covers hostname.
+# preStop is 30s (vs 15s elsewhere) — flash has more persistent TCP connections.
+# terminationGracePeriodSeconds stays at 120s (set in template, not here).
 flash:
   topologySpreadConstraints:
     enabled: true
     maxSkew: 1
-    # Zone only — ScheduleAnyway so single-zone clusters are not blocked.
-    whenUnsatisfiable: ScheduleAnyway
-
-  # Rolling update — 1 pod (all 3 containers) unavailable at a time.
+    whenUnsatisfiable: ScheduleAnyway   # zone only; hostname covered by hard anti-affinity
   updateStrategy:
     type: RollingUpdate
     maxUnavailable: 1
-
-  # Graceful shutdown — 30s preStop (more connections than other workloads).
-  # terminationGracePeriodSeconds stays at 120s (already set in template).
   preStopSleepSeconds: 30
-
-  # PodDisruptionBudget — keep N-1 pods alive during drains/upgrades.
-  # Root values.yaml sets replicaCount=2 → minAvailable=1 (N-1).
+  # N-1 for replicaCount=2
   pdb:
     enabled: true
     minAvailable: 1
 
-# ── High-availability scheduling controls for logiq-flash-ml ───────────────────
-
-# Feature 1: topologySpreadConstraints — soft spread across nodes and zones.
-# ScheduleAnyway means a pod is never left Pending due to topology skew.
 ml:
   topologySpreadConstraints:
     enabled: true
     maxSkew: 1
-    whenUnsatisfiable: ScheduleAnyway
-
-  # Feature 2: preferred pod anti-affinity — weight 100, never blocks scheduling.
-  # NOTE: podPerNode (line below) uses requiredDuringScheduling which is a hard
-  # rule and can cause Pending pods when nodes < replicas. The preferred
-  # anti-affinity here is additive and never blocks.
+    whenUnsatisfiable: ScheduleAnyway   # soft — never blocks scheduling
+  # Preferred anti-affinity: additive alongside the hard podPerNode rule, never blocks.
   podAntiAffinity:
     enabled: true
     weight: 100
-
-  # Feature 4: rolling update — 1 pod unavailable at a time.
   updateStrategy:
     type: RollingUpdate
     maxUnavailable: 1
-
-  # Feature 5: graceful shutdown — preStop(15s) fills LB-drain gap before SIGTERM.
   terminationGracePeriodSeconds: 60
   preStopSleepSeconds: 15
-
-  # Feature 3: PodDisruptionBudget — keep N-1 pods alive during drains/upgrades.
-  # Root values.yaml sets replicaCountMl=2 → minAvailable=1 (N-1).
+  # N-1 for replicaCountMl=2
   pdb:
     enabled: true
     minAvailable: 1

--- a/apica-ascent/charts/logiq-flash/values.yaml
+++ b/apica-ascent/charts/logiq-flash/values.yaml
@@ -228,12 +228,6 @@ resources:
   #  cpu: 100m
   #  memory: 128Mi
 
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
 global:
   sharedSecretName: logiq-shared-secret
   cloudProvider: aws

--- a/apica-ascent/charts/logiq-flash/values.yaml
+++ b/apica-ascent/charts/logiq-flash/values.yaml
@@ -2,8 +2,71 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 3
-replicaCountMl: 1
+replicaCount: 2
+replicaCountMl: 2
+replicaCountSync: 2
+
+# ── High-availability scheduling controls for logiq-flash-sync ─────────────────
+
+# Feature 1: topologySpreadConstraints — soft spread across nodes and zones.
+sync:
+  topologySpreadConstraints:
+    enabled: true
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway
+
+  # Feature 2: preferred pod anti-affinity — weight 100, never blocks scheduling.
+  podAntiAffinity:
+    enabled: true
+    weight: 100
+
+  # Feature 4: rolling update — 1 pod unavailable at a time.
+  updateStrategy:
+    type: RollingUpdate
+    maxUnavailable: 1
+
+  # Feature 5: graceful shutdown — preStop(15s) fills LB-drain gap before SIGTERM.
+  terminationGracePeriodSeconds: 60
+  preStopSleepSeconds: 15
+
+  # Feature 3: PodDisruptionBudget — keep N-1 pods alive during drains/upgrades.
+  # Root values.yaml sets replicaCountSync=2 → minAvailable=1 (N-1).
+  pdb:
+    enabled: true
+    minAvailable: 1
+
+# ── High-availability scheduling controls for logiq-flash-ml ───────────────────
+
+# Feature 1: topologySpreadConstraints — soft spread across nodes and zones.
+# ScheduleAnyway means a pod is never left Pending due to topology skew.
+ml:
+  topologySpreadConstraints:
+    enabled: true
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway
+
+  # Feature 2: preferred pod anti-affinity — weight 100, never blocks scheduling.
+  # NOTE: podPerNode (line below) uses requiredDuringScheduling which is a hard
+  # rule and can cause Pending pods when nodes < replicas. The preferred
+  # anti-affinity here is additive and never blocks.
+  podAntiAffinity:
+    enabled: true
+    weight: 100
+
+  # Feature 4: rolling update — 1 pod unavailable at a time.
+  updateStrategy:
+    type: RollingUpdate
+    maxUnavailable: 1
+
+  # Feature 5: graceful shutdown — preStop(15s) fills LB-drain gap before SIGTERM.
+  terminationGracePeriodSeconds: 60
+  preStopSleepSeconds: 15
+
+  # Feature 3: PodDisruptionBudget — keep N-1 pods alive during drains/upgrades.
+  # Root values.yaml sets replicaCountMl=2 → minAvailable=1 (N-1).
+  pdb:
+    enabled: true
+    minAvailable: 1
 
 image:
   repository: logiqai/flash
@@ -144,6 +207,11 @@ persistence:
 configurationFiles: true
 configMapName:
 podPerNode: false
+existingSecret:
+
+logflow_only:
+  enabled: false
+  args: ""
 
 resources: 
    sidecarTracing: {}
@@ -176,13 +244,46 @@ affinity: {}
 
 global:
   sharedSecretName: logiq-shared-secret
+  cloudProvider: aws
+
   # NodePort Configuration
   nodePort:
     enabled: false
     ports:
       flash: null
       flashMl: null
-      
+
+  nodeSelectors:
+    enabled: false
+    label: apica-node-pool
+    ingest: ingest
+    infra: base
+    other: base
+    db: common
+    cache: common
+    ingest_sync: base
+
+  taints:
+    enabled: false
+    ingest: flash
+    infra: infra
+    other: coffee
+    db: db
+    cache: cache
+    ingest_sync: sync
+
+  toolbox:
+    image:
+      repository: logiqai/toolbox
+      tag: 2.0.1
+
+  chart:
+    s3gateway: false
+    prometheus: true
+    postgres: true
+    redis: true
+    grafana: false
+
   environment:
     redis_opts: true
     redis_host: "redis-master"
@@ -196,13 +297,19 @@ global:
     s3_url: "http://s3-gateway:9000"
     s3_access: "logiq_access"
     s3_secret: "logiq_secret"
+    s3_bucket: "logiq-bucket"
     s3_region: "us-east-1"
-    AWS_ACCESS_KEY_ID: "AWS_ACCESS" 
+    s3_custom_ca:
+      enabled: false
+      map_name: "kube-root-ca.crt"
+    AWS_ACCESS_KEY_ID: "AWS_ACCESS"
     AWS_SECRET_ACCESS_KEY: "AWS_SECRET"
+    awsServiceEndpoint: "https://s3.amazonaws.com"
     extraflag: ""
+
   persistence:
     createStorageClass:
-       enabled: false
+      enabled: false
     storageClass: oci-bv
 kafka_client:
   enabled: false

--- a/apica-ascent/charts/logiq-flash/values.yaml
+++ b/apica-ascent/charts/logiq-flash/values.yaml
@@ -35,6 +35,34 @@ sync:
     enabled: true
     minAvailable: 1
 
+# ── High-availability scheduling controls for logiq-flash (primary ingest) ─────
+#
+# NOTE: logiq-flash uses a hard podAntiAffinity (podPerNode) that already
+# guarantees one-pod-per-node. The hostname topologySpreadConstraint and a
+# preferred podAntiAffinity on hostname are both omitted — they would be
+# redundant with the hard rule. Only the zone constraint adds new value.
+flash:
+  topologySpreadConstraints:
+    enabled: true
+    maxSkew: 1
+    # Zone only — ScheduleAnyway so single-zone clusters are not blocked.
+    whenUnsatisfiable: ScheduleAnyway
+
+  # Rolling update — 1 pod (all 3 containers) unavailable at a time.
+  updateStrategy:
+    type: RollingUpdate
+    maxUnavailable: 1
+
+  # Graceful shutdown — 30s preStop (more connections than other workloads).
+  # terminationGracePeriodSeconds stays at 120s (already set in template).
+  preStopSleepSeconds: 30
+
+  # PodDisruptionBudget — keep N-1 pods alive during drains/upgrades.
+  # Root values.yaml sets replicaCount=2 → minAvailable=1 (N-1).
+  pdb:
+    enabled: true
+    minAvailable: 1
+
 # ── High-availability scheduling controls for logiq-flash-ml ───────────────────
 
 # Feature 1: topologySpreadConstraints — soft spread across nodes and zones.


### PR DESCRIPTION
Added high-availability and zero-downtime features to our Ascent StatefulSet workloads.

- flash-coffee (server + worker)
- flash-discovery
- logiq-flash (ingest, ML, and sync )

Five HA features were added to every StatefulSet:

- Topology spread constraints
- Preferred pod anti-affinity
- PodDisruptionBudgets
- Explicit rolling update strategy + liveness and readiness probes
- preStop hook + terminationGracePeriodSeconds 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR implements comprehensive high-availability and zero-downtime features across five StatefulSet workloads in the apica-ascent-helm charts. The changes add topology spread constraints, pod anti-affinity rules, PodDisruptionBudgets, explicit rolling update strategies, health probes, and graceful shutdown hooks to flash-coffee (server + worker), flash-discovery, and logiq-flash (ingest, ML, and sync) components.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds PodDisruptionBudgets to all five StatefulSets (coffee-server, coffee-worker, flash-discovery, logiq-flash ingest, ML, and sync) ensuring minimum available pods during node drains and cluster upgrades.</li>

<li>Configures topology spread constraints and pod anti-affinity rules across all StatefulSets for pod distribution across nodes and availability zones, with hard anti-affinity for logiq-flash ingest when podPerNode is enabled.</li>

<li>Adds explicit RollingUpdate strategy with maxUnavailable: 1 and preStop lifecycle hooks with sleep delays (15s standard, 30s for flash ingest) paired with terminationGracePeriodSeconds (60s standard, 120s for flash ingest) for graceful rolling updates.</li>

<li>Adds liveness and readiness probes to all containers with appropriate thresholds (failureThreshold: 25 for Raft-based flash containers to avoid restart loops during WAL replay, 3 for lighter workloads).</li>

<li>Adjusts replica counts: flash-coffee server to 2, worker to 3; flash-discovery to 2; logiq-flash flash to 2, ML to 2, sync to 2 (new).</li>

</ul>
</details>

</div>