### PR TITLE
CM-1055 - Updated versions relevant to Ascent 2.16.4

### DIFF
--- a/apica-ascent/Chart.yaml
+++ b/apica-ascent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 3.1.2
-appVersion: v2.16.1
+version: 3.1.3
+appVersion: v2.16.4
 description: Apica Ascent - Cloud-native observability platform
 keywords:
   - apica

--- a/apica-ascent/values.large.yaml
+++ b/apica-ascent/values.large.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.21.1
+    tag: v3.21.2
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: v3.22.1
+      tag: v3.22.4
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 4
     image:
       repository: logiqai/flash-brew-coffee
-      tag: v3.22.1
+      tag: v3.22.4
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.medium.yaml
+++ b/apica-ascent/values.medium.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.21.1
+    tag: v3.21.2
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: v3.22.1
+      tag: v3.22.4
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 3
     image:
       repository: logiqai/flash-brew-coffee
-      tag: v3.22.1
+      tag: v3.22.4
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.single.yaml
+++ b/apica-ascent/values.single.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.21.1
+    tag: v3.21.2
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 1
     image:
       repository: logiqai/flash-brew-coffee
-      tag: v3.22.1
+      tag: v3.22.4
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 1
     image:
       repository: logiqai/flash-brew-coffee
-      tag: v3.22.1
+      tag: v3.22.4
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.small.yaml
+++ b/apica-ascent/values.small.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.21.1
+    tag: v3.21.2
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -179,7 +179,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: v3.22.1
+      tag: v3.22.4
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -191,7 +191,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: v3.22.1
+      tag: v3.22.4
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -6,7 +6,7 @@ logiq-flash:
     type: NodePort
   image:
     repository: logiqai/flash
-    tag: v3.21.1
+    tag: v3.21.2
     pullPolicy: IfNotPresent
   persistence:
     enabled: true
@@ -184,7 +184,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: v3.22.1
+      tag: v3.22.4
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -196,7 +196,7 @@ flash-coffee:
     replicaCount: 2
     image:
       repository: logiqai/flash-brew-coffee
-      tag: v3.22.1
+      tag: v3.22.4
       pullPolicy: IfNotPresent
     resources:
       requests:


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates version metadata and container image tags for the Apica Ascent Helm chart to align with the Ascent 2.16.4 release. The chart version is bumped from 3.1.2 to 3.1.3, and the appVersion is updated from v2.16.1 to v2.16.4. Container image tags for flash and flash-brew-coffee components are updated across all three values configuration files.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates Chart.yaml chart version from 3.1.2 to 3.1.3 and appVersion from v2.16.1 to v2.16.4</li>

<li>Updates logiq-flash image tag from v3.21.1 to v3.21.2 in values.large.yaml, values.medium.yaml, and values.single.yaml</li>

<li>Updates flash-brew-coffee image tag from v3.22.1 to v3.22.4 across all three values configuration files</li>

</ul>
</details>

</div>