### PR TITLE
Configure RollingUpdate Strategy for Zero-Downtime Pod Restarts & fas…

### DIFF
--- a/apica-ascent/charts/flash-coffee/templates/001-coffee-server-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/001-coffee-server-sts.yaml
@@ -15,6 +15,7 @@ spec:
   updateStrategy:
     type: {{ .Values.coffee.updateStrategy.type }}
     rollingUpdate:
+      maxSurge: {{ .Values.coffee.updateStrategy.maxSurge }}
       maxUnavailable: {{ .Values.coffee.updateStrategy.maxUnavailable }}
   template:
     metadata:

--- a/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
+++ b/apica-ascent/charts/flash-coffee/templates/003-coffee-worker-sts.yaml
@@ -15,6 +15,7 @@ spec:
   updateStrategy:
     type: {{ .Values.coffee_worker.updateStrategy.type }}
     rollingUpdate:
+      maxSurge: {{ .Values.coffee_worker.updateStrategy.maxSurge }}
       maxUnavailable: {{ .Values.coffee_worker.updateStrategy.maxUnavailable }}
   template:
     metadata:

--- a/apica-ascent/charts/flash-coffee/values.yaml
+++ b/apica-ascent/charts/flash-coffee/values.yaml
@@ -24,7 +24,8 @@ coffee:
     weight: 100
   updateStrategy:
     type: RollingUpdate
-    maxUnavailable: 1
+    maxSurge: 2
+    maxUnavailable: 0
   terminationGracePeriodSeconds: 60
   preStopSleepSeconds: 15
   # N-1 for replicaCount 2; increase minAvailable when scaling up
@@ -50,7 +51,8 @@ coffee_worker:
     weight: 100
   updateStrategy:
     type: RollingUpdate
-    maxUnavailable: 1
+    maxSurge: 2
+    maxUnavailable: 0
   terminationGracePeriodSeconds: 60
   preStopSleepSeconds: 15
   # N-1 for replicaCount 3

--- a/apica-ascent/charts/flash-discovery/templates/discoveryStatefulSet.yaml
+++ b/apica-ascent/charts/flash-discovery/templates/discoveryStatefulSet.yaml
@@ -19,6 +19,7 @@ spec:
   updateStrategy:
     type: {{ .Values.updateStrategy.type }}
     rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.maxSurge }}
       maxUnavailable: {{ .Values.updateStrategy.maxUnavailable }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/apica-ascent/charts/flash-discovery/values.yaml
+++ b/apica-ascent/charts/flash-discovery/values.yaml
@@ -15,7 +15,8 @@ podAntiAffinity:
   weight: 100
 updateStrategy:
   type: RollingUpdate
-  maxUnavailable: 1
+  maxSurge: 2
+  maxUnavailable: 0
 terminationGracePeriodSeconds: 60
 preStopSleepSeconds: 15
 # N-1 for replicaCountDiscovery=2

--- a/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulSet.yaml
@@ -19,6 +19,7 @@ spec:
   updateStrategy:
     type: {{ .Values.flash.updateStrategy.type }}
     rollingUpdate:
+      maxSurge: {{ .Values.flash.updateStrategy.maxSurge }}
       maxUnavailable: {{ .Values.flash.updateStrategy.maxUnavailable }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/apica-ascent/charts/logiq-flash/templates/statefulset-ml.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulset-ml.yaml
@@ -19,6 +19,7 @@ spec:
   updateStrategy:
     type: {{ .Values.ml.updateStrategy.type }}
     rollingUpdate:
+      maxSurge: {{ .Values.ml.updateStrategy.maxSurge }}
       maxUnavailable: {{ .Values.ml.updateStrategy.maxUnavailable }}
   volumeClaimTemplates:
     - apiVersion: v1

--- a/apica-ascent/charts/logiq-flash/templates/statefulset-sync.yaml
+++ b/apica-ascent/charts/logiq-flash/templates/statefulset-sync.yaml
@@ -19,6 +19,7 @@ spec:
   updateStrategy:
     type: {{ .Values.sync.updateStrategy.type }}
     rollingUpdate:
+      maxSurge: {{ .Values.sync.updateStrategy.maxSurge }}
       maxUnavailable: {{ .Values.sync.updateStrategy.maxUnavailable }}
   template:
     metadata:

--- a/apica-ascent/charts/logiq-flash/values.yaml
+++ b/apica-ascent/charts/logiq-flash/values.yaml
@@ -16,7 +16,8 @@ sync:
     weight: 100
   updateStrategy:
     type: RollingUpdate
-    maxUnavailable: 1
+    maxSurge: 2
+    maxUnavailable: 0
   terminationGracePeriodSeconds: 60
   preStopSleepSeconds: 15
   # N-1 for replicaCountSync=2
@@ -34,7 +35,8 @@ flash:
     whenUnsatisfiable: ScheduleAnyway   # zone only; hostname covered by hard anti-affinity
   updateStrategy:
     type: RollingUpdate
-    maxUnavailable: 1
+    maxSurge: 2
+    maxUnavailable: 0
   preStopSleepSeconds: 30
   # N-1 for replicaCount=2
   pdb:
@@ -52,7 +54,8 @@ ml:
     weight: 100
   updateStrategy:
     type: RollingUpdate
-    maxUnavailable: 1
+    maxSurge: 2
+    maxUnavailable: 0
   terminationGracePeriodSeconds: 60
   preStopSleepSeconds: 15
   # N-1 for replicaCountMl=2

--- a/apica-ascent/templates/envoy-gateway-deployment.yaml
+++ b/apica-ascent/templates/envoy-gateway-deployment.yaml
@@ -20,10 +20,10 @@ spec:
       app.kubernetes.io/name: gateway-helm
       control-plane: envoy-gateway
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+  rollingUpdate:
+    maxSurge: {{ .Values.envoyGateway.updateStrategy.maxSurge }}
+    maxUnavailable: {{ .Values.envoyGateway.updateStrategy.maxUnavailable }}
+  type: {{ .Values.envoyGateway.updateStrategy.type }}
   template:
     metadata:
       annotations:

--- a/apica-ascent/values.yaml
+++ b/apica-ascent/values.yaml
@@ -274,6 +274,10 @@ gateway:
 # Envoy Gateway Configuration for Oracle Cloud (OKE)
 envoyGateway:
   enabled: true
+  updateStrategy:
+    type: RollingUpdate
+    maxSurge: 2
+    maxUnavailable: 0
 
   controller:
     clusterRoleName: eg-gateway-helm-envoy-gateway-role


### PR DESCRIPTION
…t rollout 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR configures RollingUpdate strategy across multiple StatefulSets and a Deployment in the apica-ascent Helm chart to enable zero-downtime pod restarts. By setting maxSurge to 2 and maxUnavailable to 0 across all components, the deployment strategy ensures new pods are created before terminating old ones, preventing any service interruption during updates.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Added maxSurge: 2 and maxUnavailable: 0 to coffee-server and coffee-worker StatefulSets in flash-coffee chart, enabling zero-downtime rolling updates</li>

<li>Added maxSurge: 2 and maxUnavailable: 0 to discovery StatefulSet in flash-discovery chart for zero-downtime updates</li>

<li>Added maxSurge: 2 and maxUnavailable: 0 to flash, ml, and sync StatefulSets in logiq-flash chart for zero-downtime updates</li>

<li>Converted Envoy Gateway deployment from hardcoded update strategy (25% maxSurge/maxUnavailable) to configurable template variables with maxSurge: 2 and maxUnavailable: 0</li>

</ul>
</details>

</div>